### PR TITLE
spec/keeper: Adds Skip threshold and threshold emission tracking

### DIFF
--- a/Specs/Quint/voteBookkeeper.qnt
+++ b/Specs/Quint/voteBookkeeper.qnt
@@ -302,4 +302,22 @@ module voteBookkeeper {
         .then(applyVoteAction({typ: "Precommit", round: 1, value: "proposal", address: "alive"}, 60))
         .then(all{ assert(lastEmitted == {round: 1, name: "PrecommitValue", value: "proposal"}), allUnchanged })
     }
+
+    // Reaching PolkaAny 
+    run polkaAnyTest = {
+        init(100)
+        .then(applyVoteAction({typ: "Prevote", round: 1, value: "val1", address: "alice"}, 60))
+        .then(all{ assert(lastEmitted == {round: 1, name: "None", value: "null"}), allUnchanged })
+        .then(applyVoteAction({typ: "Prevote", round: 1, value: "nil", address: "john"}, 10))
+        .then(all{ assert(lastEmitted == {round: 1, name: "PolkaAny", value: "null"}), allUnchanged })
+    }
+
+    // Reaching PolkaNil
+    run polkaNilTest = {
+        init(100)
+        .then(applyVoteAction({typ: "Prevote", round: 1, value: "nil", address: "alice"}, 60))
+        .then(all{ assert(lastEmitted == {round: 1, name: "None", value: "null"}), allUnchanged })
+        .then(applyVoteAction({typ: "Prevote", round: 1, value: "nil", address: "john"}, 10))
+        .then(all{ assert(lastEmitted == {round: 1, name: "PolkaNil", value: "null"}), allUnchanged })
+    }
 }


### PR DESCRIPTION
The vote bookkeeper now emits a skip threshold when f+1 for any value in a given round is reached. This PR also adds logic to avoid emitting the same threshold multiple times (only emitted the first time the quorum is reached).

Emission logic:
- After applying a vote, the keeper always returns an event.
- Each event is emitted once, except for "None" which can be emitted an unbounded number of times.
- The keeper emits a Skip event only if no quorum event has been previously emitted for that round.