### PR TITLE
fix(spec): Always start propose timeout

### DIFF
--- a/specs/quint/specs/TendermintDSL.qnt
+++ b/specs/quint/specs/TendermintDSL.qnt
@@ -31,10 +31,6 @@ run ListDeliverVote (active, voteMsg) = {
     active.length().reps(i => deliverVote(active[i], voteMsg))
 }
 
-run ListDeliverVote (active, voteMsg) = {
-    active.length().reps(i => deliverVote(active[i], voteMsg))
-}
-
 run ListDeliverSomeProposal (active) = {
     all{
         assert( Faulty != Set() or 


### PR DESCRIPTION
This is the simple part for #81 to start timeoutPropose also at the Proposer. 

The GetValue logic (adding consensus inputs and outputs and actions) will be done in another PR once #154, #156, and this PR are merged.

---

### PR author checklist

- [x] Reference GitHub issue
- [x] Ensure PR title follows the [conventional commits][conv-commits] spec

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
