### PR TITLE
feat(gossip): gossip actor message config idea

### DIFF
--- a/code/actors/src/gossip.rs
+++ b/code/actors/src/gossip.rs
@@ -74,7 +74,7 @@ impl Actor for Gossip {
         myself: ActorRef<Msg>,
         args: Args,
     ) -> Result<State, ActorProcessingErr> {
-        let handle = malachite_gossip::spawn(args.keypair, args.addr, args.config).await?;
+        let handle = malachite_gossip::spawn(args.keypair, args.addr, args.config, Channel::Consensus).await?;
         let (mut recv_handle, ctrl_handle) = handle.split();
 
         let recv_task = tokio::spawn({


### PR DESCRIPTION
Closes: #XXX

We can configure the gossip actor to sign up for different topics. This way, we can reuse the gossip actor and create multiple separate networks.

Just an idea. We could pass direct strings too, we don't need the channel struct.
---

### PR author checklist

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
