### PR TITLE
chore(code): Allow overriding any part of the config using environment variables

### DIFF
--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -35,6 +35,7 @@ base64             = "0.22.0"
 bytesize           = "1.3"
 clap               = "4.5.4"
 color-eyre         = "0.6"
+config             = { version = "0.14", features = ["toml"], default-features = false }
 eyre               = "0.6"
 derive-where       = "1.2.7"
 directories        = "5.0.1"

--- a/code/crates/cli/Cargo.toml
+++ b/code/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ malachite-test.workspace   = true
 bytesize           = { workspace = true }
 clap               = { workspace = true, features = ["derive", "env"] }
 color-eyre         = { workspace = true }
+config             = { workspace = true }
 directories        = { workspace = true }
 humantime          = { workspace = true }
 itertools          = { workspace = true }


### PR DESCRIPTION
Previously, only the config options we were manually overriding from the environment were supported.

With this PR, we get automatic override from env variables of every single config option.

The environment variables have not changed.