### PR TITLE
feat(spec): Proofs scheduling protocol, English specification

### DIFF
--- a/specs/english/proofs_scheduling.md
+++ b/specs/english/proofs_scheduling.md
@@ -314,7 +314,7 @@ where `strand(H) == s`, can only produce and propose a block if it includes
   know, although not yet installed. The validator set is the input used to
   compute the proposer for each round and height, therefore needs to be known a
   priori.
-  We must discuss the relation between `E`, the epoch length, and `K`, the
+  We must discuss the relation between the constants `E`, the epoch length, and `K`, the
   number of strands.
 
 [starkprover]: https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-architecture-overview/#provers


### PR DESCRIPTION
Contributes to #237.

Rendered: https://github.com/informalsystems/malachite/blob/cason/proofs-english-spec/specs/english/proofs_scheduling.md

Main reference: https://docs.google.com/document/d/1qjngaq9GoMWa5UJOrTlKNqwi_pI0aHt8iULWD9Gy9hE/edit

There are some pending tasks:
 - How to relate the proofs scheduling with the validator set updates (epochs)
 - Maybe some suggestion to prevent blocking the algorithm when too many empty blocks are produced

Ideally, this spec should be aligned with the Quint spec of the same protocol: #198.

---

### PR author checklist

- [x] Reference GitHub issue
- [x] Ensure PR title follows the [conventional commits][conv-commits] spec

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
