### PR TITLE
fix(code/gossip): Fix for GossipSub messages being wrongly marked as duplicate when broadcasting

### DIFF
--- a/code/crates/gossip-consensus/src/behaviour.rs
+++ b/code/crates/gossip-consensus/src/behaviour.rs
@@ -20,8 +20,12 @@ pub struct Behaviour {
 }
 
 fn message_id(message: &gossipsub::Message) -> gossipsub::MessageId {
-    let hash = seahash::hash(&message.data);
-    gossipsub::MessageId::new(hash.to_le_bytes().as_slice())
+    use seahash::SeaHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = SeaHasher::new();
+    message.hash(&mut hasher);
+    gossipsub::MessageId::new(hasher.finish().to_be_bytes().as_slice())
 }
 
 fn gossipsub_config() -> gossipsub::Config {

--- a/code/crates/gossip-consensus/src/lib.rs
+++ b/code/crates/gossip-consensus/src/lib.rs
@@ -215,10 +215,13 @@ async fn handle_ctrl_msg<Ctx: Context>(
 
             match result {
                 Ok(message_id) => {
-                    debug!("Broadcasted message {message_id} of {msg_size} bytes");
+                    debug!(
+                        %channel,
+                        "Broadcasted message {message_id} of {msg_size} bytes"
+                    );
                 }
                 Err(e) => {
-                    error!("Error broadcasting message: {e}");
+                    error!(%channel, "Error broadcasting message: {e}");
                 }
             }
 


### PR DESCRIPTION
This would sometimes cause proposal parts or other messages to never be broadcast.

We need to hash the whole message, including the metadata (eg. sequence number) and not just the message data.