### PR TITLE
feat(code): Add `select_proposer` method to `Context` trait

### DIFF
--- a/code/crates/common/src/context.rs
+++ b/code/crates/common/src/context.rs
@@ -36,6 +36,14 @@ where
     /// The signing scheme used to sign votes.
     type SigningScheme: SigningScheme;
 
+    /// Select a proposer in the validator set for the given height and round.
+    fn select_proposer<'a>(
+        &self,
+        validator_set: &'a Self::ValidatorSet,
+        height: Self::Height,
+        round: Round,
+    ) -> &'a Self::Validator;
+
     /// Sign the given vote with our private key.
     fn sign_vote(&self, vote: Self::Vote) -> SignedMessage<Self, Self::Vote>;
 

--- a/code/crates/consensus/src/handle/driver.rs
+++ b/code/crates/consensus/src/handle/driver.rs
@@ -126,7 +126,7 @@ where
 {
     match output {
         DriverOutput::NewRound(height, round) => {
-            let proposer = state.get_proposer(height, round)?;
+            let proposer = state.get_proposer(height, round);
 
             apply_driver_input(
                 co,

--- a/code/crates/consensus/src/handle/proposal.rs
+++ b/code/crates/consensus/src/handle/proposal.rs
@@ -128,7 +128,7 @@ where
         return Ok(false);
     };
 
-    let expected_proposer = state.get_proposer(proposal_height, proposal_round).unwrap(); // FIXME: Unwrap
+    let expected_proposer = state.get_proposer(proposal_height, proposal_round);
 
     if expected_proposer != proposer_address {
         warn!(

--- a/code/crates/consensus/src/handle/start_height.rs
+++ b/code/crates/consensus/src/handle/start_height.rs
@@ -38,7 +38,7 @@ where
     let round = Round::new(0);
     info!(%height, "Starting new height");
 
-    let proposer = state.get_proposer(height, round).cloned()?;
+    let proposer = state.get_proposer(height, round).clone();
 
     apply_driver_input(
         co,

--- a/code/crates/consensus/src/state.rs
+++ b/code/crates/consensus/src/state.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, VecDeque};
 use malachite_common::*;
 use malachite_driver::Driver;
 
-use crate::error::Error;
 use crate::input::Input;
 use crate::Params;
 use crate::ProposedValue;
@@ -57,28 +56,10 @@ where
         }
     }
 
-    pub fn get_proposer(
-        &self,
-        height: Ctx::Height,
-        round: Round,
-    ) -> Result<&Ctx::Address, Error<Ctx>> {
-        assert!(self.driver.validator_set.count() > 0);
-        assert!(round != Round::Nil && round.as_i64() >= 0);
-
-        let proposer_index = {
-            let height = height.as_u64() as usize;
-            let round = round.as_i64() as usize;
-
-            (height - 1 + round) % self.driver.validator_set.count()
-        };
-
-        let proposer = self
-            .driver
-            .validator_set
-            .get_by_index(proposer_index)
-            .ok_or(Error::ProposerNotFound(height, round))?;
-
-        Ok(proposer.address())
+    pub fn get_proposer(&self, height: Ctx::Height, round: Round) -> &Ctx::Address {
+        self.ctx
+            .select_proposer(&self.driver.validator_set, height, round)
+            .address()
     }
 
     pub fn store_signed_precommit(&mut self, precommit: SignedVote<Ctx>) {

--- a/code/crates/starknet/host/src/mock/context.rs
+++ b/code/crates/starknet/host/src/mock/context.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use malachite_common::{Context, NilOrVal, Round, SignedProposal, SignedProposalPart, SignedVote};
+use malachite_common::{
+    Context, NilOrVal, Round, SignedProposal, SignedProposalPart, SignedVote, ValidatorSet as _,
+};
 use malachite_starknet_p2p_types::{PrivateKey, PublicKey, Signature, SigningScheme};
 use starknet_core::utils::starknet_keccak;
 
@@ -31,6 +33,27 @@ impl Context for MockContext {
     type Value = BlockHash;
     type Vote = Vote;
     type SigningScheme = SigningScheme;
+
+    fn select_proposer<'a>(
+        &self,
+        validator_set: &'a Self::ValidatorSet,
+        height: Self::Height,
+        round: Round,
+    ) -> &'a Self::Validator {
+        assert!(validator_set.count() > 0);
+        assert!(round != Round::Nil && round.as_i64() >= 0);
+
+        let proposer_index = {
+            let height = height.as_u64() as usize;
+            let round = round.as_i64() as usize;
+
+            (height - 1 + round) % validator_set.count()
+        };
+
+        validator_set
+            .get_by_index(proposer_index)
+            .expect("proposer_index is valid")
+    }
 
     fn sign_vote(&self, vote: Self::Vote) -> SignedVote<Self> {
         let hash = starknet_keccak(&vote.to_sign_bytes());

--- a/code/crates/test/src/context.rs
+++ b/code/crates/test/src/context.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use malachite_common::{Context, NilOrVal, Round, SignedProposal, SignedProposalPart, SignedVote};
+use malachite_common::{
+    Context, NilOrVal, Round, SignedProposal, SignedProposalPart, SignedVote, ValidatorSet as _,
+};
 
 use crate::address::*;
 use crate::height::*;
@@ -34,6 +36,27 @@ impl Context for TestContext {
     type Value = Value;
     type Vote = Vote;
     type SigningScheme = Ed25519;
+
+    fn select_proposer<'a>(
+        &self,
+        validator_set: &'a Self::ValidatorSet,
+        height: Self::Height,
+        round: Round,
+    ) -> &'a Self::Validator {
+        assert!(validator_set.count() > 0);
+        assert!(round != Round::Nil && round.as_i64() >= 0);
+
+        let proposer_index = {
+            let height = height.as_u64() as usize;
+            let round = round.as_i64() as usize;
+
+            (height - 1 + round) % validator_set.count()
+        };
+
+        validator_set
+            .get_by_index(proposer_index)
+            .expect("proposer_index is valid")
+    }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
     fn sign_vote(&self, vote: Self::Vote) -> SignedVote<Self> {


### PR DESCRIPTION
Closes: #437 

This allows app-developers to customize the proposer selection algorithm.

---

### PR author checklist

- [x] Reference GitHub issue
- [x] Ensure PR title follows the [conventional commits][conv-commits] spec

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
