### PR TITLE
chore(code): Use non-blocking tracing subscriber

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -689,6 +689,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,6 +2456,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -4440,6 +4450,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -117,4 +117,5 @@ tokio-stream       = "0.1"
 toml               = "0.8.19"
 tikv-jemallocator  = "0.6.0"
 tracing            = "0.1.40"
+tracing-appender   = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/code/crates/cli/Cargo.toml
+++ b/code/crates/cli/Cargo.toml
@@ -27,6 +27,7 @@ directories        = { workspace = true }
 itertools          = { workspace = true }
 tokio              = { workspace = true, features = ["full"] }
 tracing            = { workspace = true }
+tracing-appender   = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json"] }
 serde_json         = { workspace = true }
 rand               = { workspace = true }

--- a/code/crates/cli/src/main.rs
+++ b/code/crates/cli/src/main.rs
@@ -26,7 +26,9 @@ pub fn main() -> Result<()> {
     let config = args.load_config();
     let logging = config.as_ref().map(|c| c.logging).unwrap_or_default();
 
-    logging::init(logging.log_level, logging.log_format);
+    // This is a drop guard responsible for flushing any remaining logs when the program terminates.
+    // It must be assigned to a binding that is not _, as _ will result in the guard being dropped immediately.
+    let _guard = logging::init(logging.log_level, logging.log_format);
 
     trace!("Command-line parameters: {args:?}");
 


### PR DESCRIPTION
With `tracing-appender` log messages are sent to a non-blocking, off-thread writer.

> This spawns a dedicated worker thread which is responsible for writing log lines to the provided writer. When a line is written using the returned NonBlocking struct’s make_writer method, it will be enqueued to be written by the worker thread.