### PR TITLE
chore(code): Bump `libp2p-scatter` to v0.1.1

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -2435,15 +2435,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-scatter"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2930693ddb135900c3efb19b26493495ad8fa422b01d72375ddfa879ba306e78"
+checksum = "14fe352c950cea000ecc697e2e71ce22a3586b607d74104ec6aaf22deaef1883"
 dependencies = [
  "bytes",
  "fnv",
  "futures",
  "libp2p",
  "prometheus-client",
+ "tracing",
  "unsigned-varint 0.8.0",
 ]
 

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -119,7 +119,7 @@ itertools          = "0.13"
 itf                = "0.2.3"
 libp2p             = { version = "0.54.1", features = ["macros", "identify", "tokio", "ed25519", "ecdsa", "tcp", "quic", "noise", "yamux", "gossipsub", "dns", "ping", "metrics", "request-response", "cbor", "serde"] }
 libp2p-identity    = "0.2.10"
-libp2p-broadcast   = { version = "0.1.0", package = "libp2p-scatter" }
+libp2p-broadcast   = { version = "0.1.1", package = "libp2p-scatter" }
 multiaddr          = "0.18.2"
 nix                = { version = "0.29.0", features = ["signal"] }
 num-bigint         = "0.4.4"


### PR DESCRIPTION
Fixes https://github.com/romac/libp2p-scatter/issues/2

Thanks @BastienFaivre for discovering, reporting and fixing the issue!
