### PR TITLE
chore(code): Add `SignProposal` and `SignVote` effects

### DIFF
--- a/code/crates/actors/src/consensus.rs
+++ b/code/crates/actors/src/consensus.rs
@@ -804,6 +804,30 @@ where
                 Ok(Resume::Continue)
             }
 
+            Effect::SignProposal(proposal) => {
+                let start = Instant::now();
+
+                let signed_proposal = self.ctx.sign_proposal(proposal);
+
+                self.metrics
+                    .signature_signing_time
+                    .observe(start.elapsed().as_secs_f64());
+
+                Ok(Resume::SignedProposal(signed_proposal))
+            }
+
+            Effect::SignVote(vote) => {
+                let start = Instant::now();
+
+                let signed_vote = self.ctx.sign_vote(vote);
+
+                self.metrics
+                    .signature_signing_time
+                    .observe(start.elapsed().as_secs_f64());
+
+                Ok(Resume::SignedVote(signed_vote))
+            }
+
             Effect::VerifySignature(msg, pk) => {
                 use malachite_consensus::ConsensusMsg as Msg;
 

--- a/code/crates/consensus/src/effect.rs
+++ b/code/crates/consensus/src/effect.rs
@@ -55,6 +55,14 @@ where
     /// Resume with: [`Resume::ValidatorSet`]
     GetValidatorSet(Ctx::Height),
 
+    /// Sign a vote with this node's private key
+    /// Resume with: [`Resume::SignedVote`]
+    SignVote(Ctx::Vote),
+
+    /// Sign a proposal with this node's private key
+    /// Resume with: [`Resume::SignedProposal`]
+    SignProposal(Ctx::Proposal),
+
     /// Verify a signature
     /// Resume with: [`Resume::SignatureValidity`]
     VerifySignature(SignedMessage<Ctx, ConsensusMsg<Ctx>>, PublicKey<Ctx>),
@@ -63,13 +71,13 @@ where
     /// Resume with: [`Resume::Continue`]
     Decide { certificate: CommitCertificate<Ctx> },
 
-    /// Consensus has been stuck in Prevote or Precommit step,
-    /// ask for vote sets from peers
+    /// Consensus has been stuck in Prevote or Precommit step, ask for vote sets from peers
     /// Resume with: [`Resume::Continue`]
     GetVoteSet(Ctx::Height, Round),
 
     /// A peer has required our vote set, send the response
     SendVoteSetResponse(RequestId, Ctx::Height, Round, VoteSet<Ctx>),
+
     /// Persist a consensus message in the Write-Ahead Log for crash recovery
     PersistMessage(SignedConsensusMsg<Ctx>),
 
@@ -97,4 +105,10 @@ where
 
     /// Resume execution with the validity of the signature just verified
     SignatureValidity(bool),
+
+    /// Resume execution with the signed vote
+    SignedVote(SignedMessage<Ctx, Ctx::Vote>),
+
+    /// Resume execution with the signed proposal
+    SignedProposal(SignedMessage<Ctx, Ctx::Proposal>),
 }

--- a/code/crates/consensus/src/handle/signature.rs
+++ b/code/crates/consensus/src/handle/signature.rs
@@ -10,7 +10,37 @@ pub async fn verify_signature<Ctx>(
 where
     Ctx: Context,
 {
-    let effect = Effect::VerifySignature(signed_msg, validator.public_key().clone());
-    let valid = perform!(co, effect, Resume::SignatureValidity(valid) => valid);
+    let valid = perform!(co,
+        Effect::VerifySignature(signed_msg, validator.public_key().clone()),
+        Resume::SignatureValidity(valid) => valid
+    );
+
     Ok(valid)
+}
+
+pub async fn sign_vote<Ctx>(co: &Co<Ctx>, vote: Ctx::Vote) -> Result<SignedVote<Ctx>, Error<Ctx>>
+where
+    Ctx: Context,
+{
+    let signed_vote = perform!(co,
+        Effect::SignVote(vote),
+        Resume::SignedVote(signed_vote) => signed_vote
+    );
+
+    Ok(signed_vote)
+}
+
+pub async fn sign_proposal<Ctx>(
+    co: &Co<Ctx>,
+    proposal: Ctx::Proposal,
+) -> Result<SignedProposal<Ctx>, Error<Ctx>>
+where
+    Ctx: Context,
+{
+    let signed_proposal = perform!(co,
+        Effect::SignProposal(proposal),
+        Resume::SignedProposal(signed_proposal) => signed_proposal
+    );
+
+    Ok(signed_proposal)
 }

--- a/code/crates/metrics/src/metrics.rs
+++ b/code/crates/metrics/src/metrics.rs
@@ -90,6 +90,9 @@ pub struct Inner {
     /// Current round
     pub round: Gauge,
 
+    /// Time taken to sign a message
+    pub signature_signing_time: Histogram,
+
     /// Time taken to verify a signature
     pub signature_verification_time: Histogram,
 
@@ -121,6 +124,7 @@ impl Metrics {
             connected_peers: Gauge::default(),
             height: Gauge::default(),
             round: Gauge::default(),
+            signature_signing_time: Histogram::new(exponential_buckets(0.001, 2.0, 10)),
             signature_verification_time: Histogram::new(exponential_buckets(0.001, 2.0, 10)),
             instant_consensus_started: Arc::new(AtomicInstant::empty()),
             instant_block_started: Arc::new(AtomicInstant::empty()),
@@ -208,6 +212,12 @@ impl Metrics {
                 "round",
                 "Current round",
                 metrics.round.clone(),
+            );
+
+            registry.register(
+                "signature_signing_time",
+                "Time taken to sign a message, in seconds",
+                metrics.signature_signing_time.clone(),
             );
 
             registry.register(


### PR DESCRIPTION
Closes: #XXX

This brings us one step closer to removing signature-related methods from the `Context` and leaving those to the host.

---

### PR author checklist

- [ ] Reference GitHub issue
- [ ] Ensure PR title follows the [conventional commits][conv-commits] spec

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
