### PR TITLE
feat(code): allow nodes to run in sync-only mode without participating in consensus

### DIFF
--- a/code/crates/app/src/spawn.rs
+++ b/code/crates/app/src/spawn.rs
@@ -226,6 +226,7 @@ fn make_gossip_config(cfg: &ConsensusConfig) -> NetworkConfig {
         channel_names: ChannelNames::default(),
         rpc_max_size: cfg.p2p.rpc_max_size.as_u64() as usize,
         pubsub_max_size: cfg.p2p.pubsub_max_size.as_u64() as usize,
+        enable_consensus: cfg.enabled,
         enable_sync: true,
     }
 }

--- a/code/crates/config/src/lib.rs
+++ b/code/crates/config/src/lib.rs
@@ -495,6 +495,13 @@ impl FromStr for ScoringStrategy {
 /// Consensus configuration options
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ConsensusConfig {
+    /// Enable consensus protocol participation
+    ///
+    /// When disabled, the node only runs the synchronization protocol
+    /// and does not subscribe to consensus-related topics
+    #[serde(default)]
+    pub enabled: bool,
+
     /// Timeouts
     #[serde(flatten)]
     pub timeouts: TimeoutConfig,

--- a/code/crates/engine/src/util/output_port.rs
+++ b/code/crates/engine/src/util/output_port.rs
@@ -178,7 +178,7 @@ impl OutputPortSubscription {
 /// `From<T>` to convert the published message type to its own message format.
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// // First, define the publisher's message types, including a variant for
 /// // subscribing `OutputPortSubscriber`s and another for publishing messages:
 /// use ractor::{
@@ -192,7 +192,6 @@ impl OutputPortSubscription {
 ///     Subscribe(OutputPortSubscriber<u8>), // Message type for subscribing an actor to the output port
 /// }
 ///
-/// #[cfg(feature = "cluster")]
 /// impl Message for PublisherMessage {
 ///     fn serializable() -> bool {
 ///         false
@@ -251,7 +250,6 @@ impl OutputPortSubscription {
 ///     Handle(String), // Subscriber's intent for message handling
 /// }
 ///
-/// #[cfg(feature = "cluster")]
 /// impl Message for SubscriberMessage {
 ///     fn serializable() -> bool {
 ///         false

--- a/code/crates/network/src/behaviour.rs
+++ b/code/crates/network/src/behaviour.rs
@@ -157,7 +157,8 @@ impl Behaviour {
 
         let ping = ping::Behaviour::new(ping::Config::new().with_interval(Duration::from_secs(5)));
 
-        let gossipsub = config.pubsub_protocol.is_gossipsub().then(|| {
+        let enable_gossipsub = config.pubsub_protocol.is_gossipsub() && config.enable_consensus;
+        let gossipsub = enable_gossipsub.then(|| {
             gossipsub::Behaviour::new(
                 gossipsub::MessageAuthenticity::Signed(keypair.clone()),
                 gossipsub_config(config.gossipsub, config.pubsub_max_size),
@@ -169,7 +170,8 @@ impl Behaviour {
             )
         });
 
-        let enable_broadcast = config.pubsub_protocol.is_broadcast() || config.enable_sync;
+        let enable_broadcast = (config.pubsub_protocol.is_broadcast() && config.enable_consensus)
+            || config.enable_sync;
         let broadcast = enable_broadcast.then(|| {
             broadcast::Behaviour::new_with_metrics(
                 broadcast::Config {

--- a/code/crates/network/src/lib.rs
+++ b/code/crates/network/src/lib.rs
@@ -95,6 +95,7 @@ pub struct Config {
     pub channel_names: ChannelNames,
     pub rpc_max_size: usize,
     pub pubsub_max_size: usize,
+    pub enable_consensus: bool,
     pub enable_sync: bool,
 }
 
@@ -241,15 +242,17 @@ async fn run(
 
     state.discovery.dial_bootstrap_nodes(&swarm);
 
-    if let Err(e) = pubsub::subscribe(
-        &mut swarm,
-        config.pubsub_protocol,
-        Channel::consensus(),
-        config.channel_names,
-    ) {
-        error!("Error subscribing to consensus channels: {e}");
-        return;
-    };
+    if config.enable_consensus {
+        if let Err(e) = pubsub::subscribe(
+            &mut swarm,
+            config.pubsub_protocol,
+            Channel::consensus(),
+            config.channel_names,
+        ) {
+            error!("Error subscribing to consensus channels: {e}");
+            return;
+        };
+    }
 
     if config.enable_sync {
         if let Err(e) = pubsub::subscribe(

--- a/code/crates/network/test/src/lib.rs
+++ b/code/crates/network/test/src/lib.rs
@@ -163,6 +163,7 @@ impl<const N: usize> Test<N> {
             channel_names: malachitebft_network::ChannelNames::default(),
             rpc_max_size: 10 * 1024 * 1024,   // 10 MiB
             pubsub_max_size: 4 * 1024 * 1024, // 4 MiB
+            enable_consensus: true,
             enable_sync: false,
         })
     }

--- a/code/crates/starknet/host/src/node.rs
+++ b/code/crates/starknet/host/src/node.rs
@@ -250,6 +250,7 @@ fn make_config(index: usize, total: usize, settings: MakeConfigSettings) -> Conf
     Config {
         moniker: format!("starknet-{index}"),
         consensus: ConsensusConfig {
+            enabled: true,
             value_payload: ValuePayload::PartsOnly,
             queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
             timeouts: TimeoutConfig::default(),
@@ -347,6 +348,7 @@ fn make_distributed_config(
     Config {
         moniker: format!("starknet-{index}"),
         consensus: ConsensusConfig {
+            enabled: true,
             queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
             value_payload: ValuePayload::PartsOnly,
             timeouts: TimeoutConfig::default(),

--- a/code/crates/starknet/host/src/spawn.rs
+++ b/code/crates/starknet/host/src/spawn.rs
@@ -275,6 +275,7 @@ async fn spawn_network_actor(
         channel_names: ChannelNames::default(),
         rpc_max_size: cfg.consensus.p2p.rpc_max_size.as_u64() as usize,
         pubsub_max_size: cfg.consensus.p2p.pubsub_max_size.as_u64() as usize,
+        enable_consensus: cfg.consensus.enabled,
         enable_sync: true,
     };
 

--- a/code/crates/starknet/test/src/lib.rs
+++ b/code/crates/starknet/test/src/lib.rs
@@ -145,6 +145,7 @@ impl TestRunner {
             moniker: format!("node-{node}"),
             logging: LoggingConfig::default(),
             consensus: ConsensusConfig {
+                enabled: true,
                 value_payload: ValuePayload::PartsOnly,
                 queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`
                 timeouts: TimeoutConfig::default(),

--- a/code/crates/test/app/config.toml
+++ b/code/crates/test/app/config.toml
@@ -28,6 +28,12 @@ log_format = "plaintext"
 #######################################################
 [consensus]
 
+# Enable consensus protocol participation
+# When disabled, the node will only run synchronization protocol 
+# and will not subscribe to consensus-related topics
+# Override with MALACHITE__CONSENSUS__ENABLED env variable
+enabled = true
+
 ## Timeouts
 
 # How long we wait for a proposal block before prevoting nil

--- a/code/crates/test/app/src/node.rs
+++ b/code/crates/test/app/src/node.rs
@@ -234,6 +234,7 @@ fn make_config(index: usize, total: usize, settings: MakeConfigSettings) -> Conf
     Config {
         moniker: format!("test-{index}"),
         consensus: ConsensusConfig {
+            enabled: true,
             // Current test app does not support proposal-only value payload properly as Init does not include valid_round
             value_payload: ValuePayload::ProposalAndParts,
             queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`

--- a/code/crates/test/framework/src/lib.rs
+++ b/code/crates/test/framework/src/lib.rs
@@ -21,7 +21,7 @@ mod logging;
 use logging::init_logging;
 
 mod node;
-pub use node::{HandlerResult, NodeId, TestNode};
+pub use node::{ConfigCustomizer, HandlerResult, NodeId, TestNode};
 
 mod params;
 pub use params::TestParams;

--- a/code/crates/test/framework/src/node.rs
+++ b/code/crates/test/framework/src/node.rs
@@ -12,6 +12,7 @@ use malachitebft_test::middleware::{DefaultMiddleware, Middleware};
 use crate::Expected;
 
 pub type NodeId = usize;
+pub type ConfigCustomizer<Config> = Arc<dyn Fn(&mut Config) + Send + Sync>;
 
 pub enum Step<Ctx, S>
 where
@@ -48,6 +49,7 @@ where
     pub steps: Vec<Step<Ctx, State>>,
     pub state: State,
     pub middleware: Arc<dyn Middleware>,
+    pub config_customizer: Option<ConfigCustomizer<malachitebft_test_app::config::Config>>,
 }
 
 impl<Ctx, State> TestNode<Ctx, State>
@@ -70,6 +72,7 @@ where
             steps: vec![],
             state,
             middleware: Arc::new(DefaultMiddleware),
+            config_customizer: None,
         }
     }
 
@@ -308,6 +311,13 @@ where
 
     pub fn full_node(&mut self) -> &mut Self {
         self.voting_power = 0;
+        self
+    }
+
+    pub fn with_consensus_disabled(&mut self) -> &mut Self {
+        self.config_customizer = Some(Arc::new(|config| {
+            config.consensus.enabled = false;
+        }));
         self
     }
 

--- a/code/crates/test/framework/src/params.rs
+++ b/code/crates/test/framework/src/params.rs
@@ -6,6 +6,7 @@ use malachitebft_test_app::config::Config;
 #[derive(Copy, Clone, Debug)]
 pub struct TestParams {
     pub enable_value_sync: bool,
+    pub consensus_enabled: bool,
     pub parallel_requests: usize,
     pub batch_size: usize,
     pub protocol: PubSubProtocol,
@@ -22,6 +23,7 @@ impl Default for TestParams {
     fn default() -> Self {
         Self {
             enable_value_sync: false,
+            consensus_enabled: true,
             parallel_requests: 1,
             batch_size: 1,
             protocol: PubSubProtocol::default(),
@@ -41,6 +43,7 @@ impl TestParams {
         config.value_sync.enabled = self.enable_value_sync;
         config.value_sync.parallel_requests = self.parallel_requests;
         config.value_sync.batch_size = self.batch_size;
+        config.consensus.enabled = self.consensus_enabled;
         config.consensus.p2p.protocol = self.protocol;
         config.consensus.value_payload = self.value_payload;
         config.test.max_block_size = self.block_size;

--- a/code/crates/test/tests/it/main.rs
+++ b/code/crates/test/tests/it/main.rs
@@ -142,6 +142,7 @@ impl TestRunner {
             moniker: format!("node-{node}"),
             logging: LoggingConfig::default(),
             consensus: ConsensusConfig {
+                enabled: true,
                 // Current test app does not support proposal-only value payload properly as Init does not include valid_round
                 value_payload: ValuePayload::ProposalAndParts,
                 queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`

--- a/code/examples/channel/config.toml
+++ b/code/examples/channel/config.toml
@@ -28,6 +28,12 @@ log_format = "plaintext"
 #######################################################
 [consensus]
 
+# Enable consensus protocol participation
+# When disabled, the node will only run synchronization protocol 
+# and will not subscribe to consensus-related topics
+# Override with MALACHITE__CONSENSUS__ENABLED env variable
+enabled = true
+
 ## Timeouts
 
 # How long we wait for a proposal block before prevoting nil

--- a/code/examples/channel/src/node.rs
+++ b/code/examples/channel/src/node.rs
@@ -224,6 +224,7 @@ fn make_config(index: usize, total: usize, settings: MakeConfigSettings) -> Conf
     Config {
         moniker: format!("app-{index}"),
         consensus: ConsensusConfig {
+            enabled: true,
             // Current channel app does not support parts-only value payload properly as Init does not include valid_round
             value_payload: ValuePayload::ProposalAndParts,
             queue_capacity: 100, // Deprecated, derived from `sync.parallel_requests`


### PR DESCRIPTION
Closes: #XXX
Adds new Sync-Only mode for Full Nodes

Behavior:

- Subscribes only to sync network topics
- Downloads and validates blocks
- Does not process consensus messages (proposals, votes, certificates)
- Does not participate in voting or proposal validation

Use Cases: 
- Block explorers, read-only applications, archival nodes
- Validators that are far behind
   - The UX is not great: starts with `consensus.enable=false`, when close to the tip, the validator needs to be manually restarted with updated config: `consensus.enable=true`
   - For this use case we should have config reload or even better rejoining consensus when getting close to the tip

---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
