### PR TITLE
chore(CCHAIN309): Check all scenarios when the driver panics

### DIFF
--- a/code/crates/core-driver/src/driver.rs
+++ b/code/crates/core-driver/src/driver.rs
@@ -475,6 +475,8 @@ where
 
         match &output {
             VKOutput::PolkaValue(val) => self.store_polka_certificate(vote_round, val),
+            // TODO: Can we have a scenario where this event is generated for a lower round
+            // and we set our round certificate for a certificate from a lower round?
             VKOutput::PrecommitAny => self.store_precommit_any_round_certificate(vote_round),
             VKOutput::SkipRound(round) => self.store_skip_round_certificate(*round),
             _ => (),

--- a/code/examples/channel/src/state.rs
+++ b/code/examples/channel/src/state.rs
@@ -141,6 +141,8 @@ impl State {
         }
 
         // Verify the proposal signature
+        // TODO: Here we assume that we can check the signature of the proposal always because the validator set is fixed
+        // In a real application, we would need to delay this verification until we know the actual validator set for this height
         match self.verify_proposal_signature(&parts) {
             Ok(()) => {
                 // Signature verified successfully, continue processing
@@ -168,19 +170,48 @@ impl State {
         }
 
         let proposal_height = parts.height;
+        let proposal_round = parts.round;
 
-        // Re-assemble the proposal from its parts
-        let value = assemble_value_from_parts(parts)?;
+        // For current height AND round, check proposer and store in undecided
+        if proposal_height == self.current_height && proposal_round == self.current_round {
+            // Check if proposer matches current proposer
+            match self.current_proposer {
+                Some(expected_proposer) if parts.proposer != expected_proposer => {
+                    error!(
+                        height = %proposal_height,
+                        round = %proposal_round,
+                        actual_proposer = %parts.proposer,
+                        expected_proposer = %expected_proposer,
+                        "Proposal not from expected proposer for current round"
+                    );
+                    return Ok(None);
+                }
+                None => {
+                    error!(
+                        height = %proposal_height,
+                        round = %proposal_round,
+                        proposer = %parts.proposer,
+                        "Received proposal but no current proposer is set"
+                    );
+                    return Ok(None);
+                }
+                _ => {
+                    // Proposer matches, proceed
+                }
+            }
 
-        if proposal_height == self.current_height {
+            // Re-assemble the proposal and store in undecided
+            let value = assemble_value_from_parts(parts)?;
             info!(%value.height, %value.round, "Storing undecided proposal");
             self.store.store_undecided_proposal(value.clone()).await?;
+            Ok(Some(value))
         } else {
+            // For other height/round, store in pending and return None
+            let value = assemble_value_from_parts(parts)?;
             info!(%value.height, %value.round, "Storing pending proposal");
             self.store.store_pending_proposal(value.clone()).await?;
+            Ok(None)
         }
-
-        Ok(Some(value))
     }
 
     /// Retrieves a decided block at the given height


### PR DESCRIPTION
Closes: #XXX

Triggered by the panic observed [here](https://github.com/circlefin/malachite/pull/1177), we decided to take a closer look to see when the driver can panic and whether it can happen as part of regular execution or only due to bugs in our code. 

There are 3 scenarios when driver can panic: 
1. in `./src/proposal_keeper.rs` when it tries to store two proposals from two different proposers. This happened in the case linked above, and we need to make sure that a proposal received from a non-proposer is dropped before it reaches the driver so this panic can never happen. 
```rust 
        // Check if the proposal is from the same validator as the first one recorded.
        // This should never happen, as proposals should always come from the same validator (round's proposer).
        if let Some(first) = self.get_first_proposal() {
            if first.validator_address() != proposal.validator_address() {
                panic!(
                    "BUG: Received proposals from different validators in the same round.\n\
                    Existing: {:?}, New: {:?}",
                    first.validator_address(),
                    proposal.validator_address()
                );
            }
        }
```
        


2. in `./src/driver.rs` we have two panics when dealing with round certificates. Namely, when the vote keeper generates `Skip` or `PrecommitAny` certificate event based on the votes it received, the driver tries to store these certificates in its `round_certificate` field. Before storing driver checks if votes for these certificates exist in the vote keeper (actually it checks if vote keeper contains votes from the same round as certificate), and if not it panics. This should never happen because the same vote keeper generated these certificate events in the first place because it has these votes.

```rust

fn store_precommit_any_round_certificate(&mut self, vote_round: Round) {
        let Some(per_round) = self.vote_keeper.per_round(vote_round) else {
            panic!("Missing the PrecommitAny votes for round {vote_round}");
        };

fn store_skip_round_certificate(&mut self, vote_round: Round) {
        let Some(per_round) = self.vote_keeper.per_round(vote_round) else {
            panic!("Missing the SkipRoundvotes for round {vote_round}");
        };

```


---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
