### PR TITLE
chore(CCHAIN361): Buffer messages for higher height before verification

### DIFF
--- a/code/crates/core-consensus/src/handle/proposal.rs
+++ b/code/crates/core-consensus/src/handle/proposal.rs
@@ -53,19 +53,6 @@ where
         return Ok(());
     }
 
-    if !verify_signed_proposal(co, state, &signed_proposal).await? {
-        return Ok(());
-    }
-
-    info!(
-        consensus.height = %consensus_height,
-        proposal.height = %proposal_height,
-        proposal.round = %proposal_round,
-        proposer = %proposer_address,
-        message = %PrettyProposal::<Ctx>(&signed_proposal.message),
-        "Received proposal"
-    );
-
     // Queue messages if driver is not initialized, or if they are for higher height.
     // Process messages received for the current height.
     // Drop all others.
@@ -84,6 +71,19 @@ where
     }
 
     debug_assert_eq!(proposal_height, consensus_height);
+
+    if !verify_signed_proposal(co, state, &signed_proposal).await? {
+        return Ok(());
+    }
+
+    info!(
+        consensus.height = %consensus_height,
+        proposal.height = %proposal_height,
+        proposal.round = %proposal_round,
+        proposer = %proposer_address,
+        message = %PrettyProposal::<Ctx>(&signed_proposal.message),
+        "Received proposal"
+    );
 
     // Store the proposal in the full proposal keeper
     state.store_proposal(signed_proposal.clone());

--- a/code/crates/core-consensus/src/handle/vote.rs
+++ b/code/crates/core-consensus/src/handle/vote.rs
@@ -62,6 +62,8 @@ where
         return Ok(());
     }
 
+    debug_assert_eq!(consensus_height, vote_height);
+
     if !verify_signed_vote(co, state, &signed_vote).await? {
         return Ok(());
     }
@@ -73,8 +75,6 @@ where
         message = %PrettyVote::<Ctx>(&signed_vote.message),
         "Received vote",
     );
-
-    debug_assert_eq!(consensus_height, vote_height);
 
     // Only process this vote if we have not yet seen it.
     if !state.driver.votes().has_vote(&signed_vote) {

--- a/code/crates/core-consensus/src/handle/vote.rs
+++ b/code/crates/core-consensus/src/handle/vote.rs
@@ -33,18 +33,6 @@ where
         return Ok(());
     }
 
-    if !verify_signed_vote(co, state, &signed_vote).await? {
-        return Ok(());
-    }
-
-    info!(
-        height = %consensus_height,
-        %vote_height,
-        address = %validator_address,
-        message = %PrettyVote::<Ctx>(&signed_vote.message),
-        "Received vote",
-    );
-
     // Queue messages if driver is not initialized, or if they are for higher height.
     // Process messages received for the current height.
     // Drop all others.
@@ -73,6 +61,18 @@ where
 
         return Ok(());
     }
+
+    if !verify_signed_vote(co, state, &signed_vote).await? {
+        return Ok(());
+    }
+
+    info!(
+        height = %consensus_height,
+        %vote_height,
+        address = %validator_address,
+        message = %PrettyVote::<Ctx>(&signed_vote.message),
+        "Received vote",
+    );
 
     debug_assert_eq!(consensus_height, vote_height);
 


### PR DESCRIPTION
Closes: #XXX

Currently, if signature verification for proposals and votes fails because validator set is not known, the messages are dropped. If these are for a higher height a validator will fall behind triggering sync recovery.

The proposed change is to buffer the future height messages immediately, before verification.

---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
