### PR TITLE
feat(code/metrics): Add metrics for consensus input queue

### DIFF
--- a/code/crates/core-consensus/src/handle/liveness.rs
+++ b/code/crates/core-consensus/src/handle/liveness.rs
@@ -30,6 +30,7 @@ where
 {
     info!(%certificate.height, %certificate.round, "Received polka certificate");
 
+    // Discard certificates for heights that do not match the current height.
     if certificate.height != state.height() {
         warn!(
             %certificate.height,
@@ -104,6 +105,7 @@ where
         "Received round certificate"
     );
 
+    // Discard certificates for heights that do not match the current height.
     if certificate.height != state.height() {
         warn!(
             %certificate.height,

--- a/code/crates/core-consensus/src/handle/proposal.rs
+++ b/code/crates/core-consensus/src/handle/proposal.rs
@@ -57,7 +57,7 @@ where
     // Queue proposals for heights higher than the current height.
     if proposal_height > consensus_height {
         debug!("Received proposal for higher height {proposal_height}, queuing for later",);
-        state.buffer_input(proposal_height, Input::Proposal(signed_proposal));
+        state.buffer_input(proposal_height, Input::Proposal(signed_proposal), metrics);
 
         return Ok(());
     }
@@ -69,7 +69,7 @@ where
     // Drop all others.
     if state.driver.round() == Round::Nil {
         debug!("Received proposal at round -1, queuing for later");
-        state.buffer_input(proposal_height, Input::Proposal(signed_proposal));
+        state.buffer_input(proposal_height, Input::Proposal(signed_proposal), metrics);
 
         return Ok(());
     }

--- a/code/crates/core-consensus/src/handle/proposed_value.rs
+++ b/code/crates/core-consensus/src/handle/proposed_value.rs
@@ -50,6 +50,7 @@ where
         state.buffer_input(
             proposed_value.height,
             Input::ProposedValue(proposed_value, origin),
+            metrics,
         );
 
         return Ok(());

--- a/code/crates/core-consensus/src/handle/start_height.rs
+++ b/code/crates/core-consensus/src/handle/start_height.rs
@@ -76,10 +76,7 @@ where
     Ctx: Context,
 {
     // Take all inputs that are pending for the current height.
-    let pending_inputs = state
-        .input_queue
-        .shift_and_take(&state.height())
-        .collect::<Vec<_>>();
+    let pending_inputs = state.take_pending_inputs(metrics);
 
     if is_restart {
         return Ok(());

--- a/code/crates/core-consensus/src/handle/sync.rs
+++ b/code/crates/core-consensus/src/handle/sync.rs
@@ -27,7 +27,7 @@ where
     if consensus_height < cert_height {
         debug!(%consensus_height, %cert_height, "Received value response for higher height, queuing for later");
 
-        state.buffer_input(cert_height, Input::SyncValueResponse(value));
+        state.buffer_input(cert_height, Input::SyncValueResponse(value), metrics);
 
         return Ok(());
     }

--- a/code/crates/core-consensus/src/handle/vote.rs
+++ b/code/crates/core-consensus/src/handle/vote.rs
@@ -43,7 +43,7 @@ where
             "Received vote for higher height, queuing for later"
         );
 
-        state.buffer_input(vote_height, Input::Vote(signed_vote));
+        state.buffer_input(vote_height, Input::Vote(signed_vote), metrics);
 
         return Ok(());
     }
@@ -59,7 +59,7 @@ where
             "Received vote at round -1, queuing for later"
         );
 
-        state.buffer_input(vote_height, Input::Vote(signed_vote));
+        state.buffer_input(vote_height, Input::Vote(signed_vote), metrics);
 
         return Ok(());
     }

--- a/code/crates/core-consensus/src/state.rs
+++ b/code/crates/core-consensus/src/state.rs
@@ -2,11 +2,11 @@ use tracing::warn;
 
 use malachitebft_core_driver::Driver;
 use malachitebft_core_types::*;
-use malachitebft_metrics::Metrics;
 
 use crate::full_proposal::{FullProposal, FullProposalKeeper};
 use crate::input::Input;
 use crate::params::Params;
+use crate::prelude::*;
 use crate::types::ProposedValue;
 use crate::util::bounded_queue::BoundedQueue;
 
@@ -185,15 +185,18 @@ where
     }
 
     /// Queue an input for later processing, only keep inputs for the highest height seen so far.
-    pub fn buffer_input(&mut self, height: Ctx::Height, input: Input<Ctx>, metrics: &Metrics) {
+    pub fn buffer_input(&mut self, height: Ctx::Height, input: Input<Ctx>, _metrics: &Metrics) {
         self.input_queue.push(height, input);
 
-        metrics.queue_heights.set(self.input_queue.len() as i64);
-        metrics.queue_size.set(self.input_queue.size() as i64);
+        #[cfg(feature = "metrics")]
+        {
+            _metrics.queue_heights.set(self.input_queue.len() as i64);
+            _metrics.queue_size.set(self.input_queue.size() as i64);
+        }
     }
 
     /// Take all inputs that are pending for the specified height and remove from the input queue.
-    pub fn take_pending_inputs(&mut self, metrics: &Metrics) -> Vec<Input<Ctx>>
+    pub fn take_pending_inputs(&mut self, _metrics: &Metrics) -> Vec<Input<Ctx>>
     where
         Ctx: Context,
     {
@@ -202,8 +205,11 @@ where
             .shift_and_take(&self.height())
             .collect::<Vec<_>>();
 
-        metrics.queue_heights.set(self.input_queue.len() as i64);
-        metrics.queue_size.set(self.input_queue.size() as i64);
+        #[cfg(feature = "metrics")]
+        {
+            _metrics.queue_heights.set(self.input_queue.len() as i64);
+            _metrics.queue_size.set(self.input_queue.size() as i64);
+        }
 
         inputs
     }

--- a/code/crates/core-consensus/src/util/bounded_queue.rs
+++ b/code/crates/core-consensus/src/util/bounded_queue.rs
@@ -82,6 +82,21 @@ where
     pub fn is_full(&self) -> bool {
         self.queue.len() >= self.capacity
     }
+
+    /// Returns true if the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    /// Returns the current number of unique indices in the queue.
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Returns the total number of values stored in the queue across all indices.
+    pub fn size(&self) -> usize {
+        self.queue.values().map(|v| v.len()).sum()
+    }
 }
 
 #[cfg(test)]

--- a/code/crates/metrics/src/metrics.rs
+++ b/code/crates/metrics/src/metrics.rs
@@ -84,6 +84,12 @@ pub struct Inner {
     /// Time taken to verify a signature
     pub signature_verification_time: Histogram,
 
+    /// Number of heights in the consensus input queue
+    pub queue_heights: Gauge,
+
+    /// Number of inputs in the consensus input queue across all heights
+    pub queue_size: Gauge,
+
     /// Internal state for measuring time taken for consensus
     instant_consensus_started: Arc<AtomicInstant>,
 
@@ -110,6 +116,8 @@ impl Metrics {
             round: Gauge::default(),
             signature_signing_time: Histogram::new(exponential_buckets(0.001, 2.0, 10)),
             signature_verification_time: Histogram::new(exponential_buckets(0.001, 2.0, 10)),
+            queue_heights: Gauge::default(),
+            queue_size: Gauge::default(),
             instant_consensus_started: Arc::new(AtomicInstant::empty()),
             instant_block_started: Arc::new(AtomicInstant::empty()),
             instant_step_started: Arc::new(Mutex::new((Step::Unstarted, Instant::now()))),
@@ -184,6 +192,18 @@ impl Metrics {
                 "signature_verification_time",
                 "Time taken to verify a signature, in seconds",
                 metrics.signature_verification_time.clone(),
+            );
+
+            registry.register(
+                "queue_heights",
+                "Number of heights in the consensus input queue",
+                metrics.queue_heights.clone(),
+            );
+
+            registry.register(
+                "queue_size",
+                "Number of inputs in the consensus input queue across all heights",
+                metrics.queue_size.clone(),
             );
         });
 


### PR DESCRIPTION
> [!NOTE]
> 📚 Stacked on top of #1188 

Closes: #XXX

Add two new metrics:

- `malachitebft_core_consensus_queue_heights`: The number of distinct heights there are inputs for in the queue
- `malachitebft_core_consensus_queue_size`: The total number of inputs in the queue

---

### PR author checklist

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
