### PR TITLE
fix: Replace panic-prone unwrap() calls with proper error handling

### DIFF
--- a/code/crates/app/src/spawn.rs
+++ b/code/crates/app/src/spawn.rs
@@ -132,7 +132,7 @@ where
     Codec: WalCodec<Ctx>,
 {
     let wal_dir = home_dir.join("wal");
-    std::fs::create_dir_all(&wal_dir).unwrap();
+    std::fs::create_dir_all(&wal_dir)?;
 
     let wal_file = wal_dir.join("consensus.wal");
 

--- a/code/crates/discovery/src/handlers/identify.rs
+++ b/code/crates/discovery/src/handlers/identify.rs
@@ -214,9 +214,11 @@ where
             }
             // Add the address to the Kademlia routing table
             if self.config.bootstrap_protocol == BootstrapProtocol::Kademlia {
-                swarm
-                    .behaviour_mut()
-                    .add_address(&peer_id, info.listen_addrs.first().unwrap().clone());
+                if let Some(addr) = info.listen_addrs.first() {
+                    swarm.behaviour_mut().add_address(&peer_id, addr.clone());
+                } else {
+                    warn!(peer = %peer_id, "No listen addresses available for Kademlia routing");
+                }
             }
         } else {
             // If discovery is disabled, all peers are inbound. The


### PR DESCRIPTION
- identify.rs: Handle empty listen_addrs with if-let instead of unwrap()
- spawn.rs: Propagate directory creation errors with ? operator
- app.rs: Handle JSON encoding errors gracefully with logging

Closes: #768

---

### PR author checklist

#### For all contributors

- [x] Reference a GitHub issue
- [x] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [x] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
