### PR TITLE
chore(ci): Add SonarQube analysis workflow and refactor coverage jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,17 +21,15 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      code: ${{ steps.filter.outputs.code }}
-      specs: ${{ steps.filter.outputs.specs }}
+      changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            code:
+            changed:
               - 'code/**'
-            specs:
               - 'specs/**'
             codecov:
               - 'codecov.yml'
@@ -39,8 +37,8 @@ jobs:
   integration:
     name: Integration
     needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.codecov == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-small
+    if: ${{ needs.changes.outputs.changed == 'true' || github.ref == 'refs/heads/main' }}
+    runs-on: 2xlarge-spot
     defaults:
       run:
         working-directory: code
@@ -68,15 +66,15 @@ jobs:
             --all-features \
             --no-capture \
             --ignore-run-fail \
-            --codecov \
-            --output-path coverage-integration.info
+            --lcov \
+            --output-path coverage-integration.lcov
       - name: Generate text report
         run: cargo llvm-cov report
       - name: Upload coverage artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: integration-coverage
-          path: code/coverage-integration.info
+          name: coverage-integration
+          path: code/coverage-integration.lcov
           retention-days: 1
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -89,28 +87,32 @@ jobs:
   mbt:
     name: MBT
     needs: changes
-    if: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.specs == 'true' || needs.changes.outputs.codecov == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-small
+    if: ${{ needs.changes.outputs.changed == 'true' || github.ref == 'refs/heads/main' }}
+    runs-on: 2xlarge-spot
     defaults:
       run:
         working-directory: code
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Run Circle actions runner setup
+        uses: circlefin/circle-runner-setup-action@v5.6
+        with:
+          repository: ${{ github.repository }}
+          branch: ${{ github.ref }}
+          extra_apt_packages: libclang-dev
       - name: Install Protoc
-        uses: step-security/setup-protoc@f6eb248a6510dbb851209febc1bd7981604a52e3 # v3
+        uses: step-security/setup-protoc@f6eb248a6510dbb851209febc1bd7981604a52e3 # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: "18"
       - name: Install Quint
         run: npm install -g @informalsystems/quint
       - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
+        uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           toolchain: nightly-2025-01-07 # pin to working nightly
           components: llvm-tools-preview
@@ -123,54 +125,30 @@ jobs:
           cargo llvm-cov nextest \
            -p informalsystems-malachitebft-test-mbt \
            -p informalsystems-malachitebft-starknet-test-mbt \
-           --all-features --codecov --output-path coverage-mbt.info
+           --all-features \
+          --ignore-run-fail \
+          --lcov \
+          --output-path coverage-mbt.lcov
       - name: Generate text report
         run: cargo llvm-cov report
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: mbt-coverage
-          path: code/coverage-mbt.info
+          name: coverage-mbt
+          path: code/coverage-mbt.lcov
           retention-days: 1
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: mbt
-          fail_ci_if_error: false
 
-  upload-coverage:
-    name: Upload coverage to Codecov
+  sonarqube:
+    name: SonarQube Analysis
     needs: [changes, integration, mbt]
-    runs-on: github-hosted-small
-    if: ${{ !cancelled() && (needs.changes.outputs.code == 'true' || needs.changes.outputs.specs == 'true' || needs.changes.outputs.codecov == 'true' || github.ref == 'refs/heads/main') }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Create coverage directory
-        run: mkdir -p code/coverage
-      - name: Download integration coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: integration-coverage
-          path: code/coverage
-      - name: Download MBT coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: mbt-coverage
-          path: code/coverage
-      - name: List coverage files
-        run: ls -la code/coverage
-      - name: Upload integration coverage to Codecov
-        working-directory: code
-        run: |
-          bash <(curl -s https://codecov.io/bash) -f coverage/coverage-integration.info -F integration
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload MBT coverage to Codecov
-        working-directory: code
-        run: |
-          bash <(curl -s https://codecov.io/bash) -f coverage/coverage-mbt.info -F mbt
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    uses: ./.github/workflows/sonarqube.yml
+    if: ${{ needs.changes.outputs.changed == 'true' || github.ref == 'refs/heads/main' }}
+    with:
+      sonar_project_key: circlefin_malachite_57a53656-ff02-a10c-9c5a-52ba9202f3a9
+      coverage_artifact_pattern: coverage-*
+      quality_gate_check: true
+      args: >
+        -Dsonar.projectVersion=${{ github.sha }}
+        -Dsonar.sources=code
+        -Dsonar.rust.cargo.manifestPaths=code/Cargo.toml
+        -Dsonar.rust.lcov.reportPaths=target/coverage-integration.lcov,target/coverage-mbt.lcov

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,18 +137,42 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     runs-on: github-hosted-small
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Run Circle actions runner setup
+        uses: circlefin/circle-runner-setup-action@v5.6
+        with:
+          repository: ${{ github.repository }}
+          branch: ${{ github.ref }}
+          extra_apt_packages: libclang-dev
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
           cache-workspaces: "code"
       - name: Run clippy
-        uses: actions-rs/clippy@master
+        run: |
+          cargo clippy --all-targets --all-features --message-format=json -- -D warnings 2>&1 | tee target/clippy-report.json
+          test ${PIPESTATUS[0]} -eq 0
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          args: --all-features --all-targets --manifest-path code/Cargo.toml
+          name: clippy-report
+          path: code/target/clippy-report.json
+          retention-days: 1
+
+  sonarqube:
+    name: SonarQube Analysis
+    needs: [changes, clippy]
+    uses: ./.github/workflows/sonarqube.yml
+    if: ${{ needs.changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+    with:
+      sonar_project_key: circlefin_malachite_57a53656-ff02-a10c-9c5a-52ba9202f3a9
+      clippy_artifact_name: clippy-report
+      quality_gate_check: true
+      args: >
+        -Dsonar.projectVersion=${{ github.sha }}
+        -Dsonar.sources=code
+        -Dsonar.rust.cargo.manifestPaths=code/Cargo.toml
+        -Dsonar.rust.clippy.reportPaths=target/clippy-report.json
 
   fmt:
     name: Formatting

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,139 @@
+name: Sonarqube Analysis
+on:
+  workflow_call:
+    inputs:
+      repository:
+        description: "Source repository to clone. Pass as github.repository expression"
+        type: string
+        required: false
+        default: ${{ github.repository }}
+      branch:
+        description: "Branch to run CI on. Pass as github.ref expression"
+        type: string
+        required: false
+        default: ${{ github.ref }}
+      sonar_project_key:
+        description: "Sonar project key (auto-generated when creating a project with GitHub Integration)"
+        type: string
+        required: true
+      clippy_artifact_name:
+        description: "Name of the Clippy report artifact to download"
+        type: string
+        required: false
+        default: ""
+      coverage_artifact_name:
+        description: "Name of the coverage report artifact to download"
+        type: string
+        required: false
+        default: ""
+      coverage_artifact_pattern:
+        description: "glob pattern to the coverage report artifacts to download, ignored if coverage_artifact_name is specified"
+        type: string
+        required: false
+        default: ""
+      sonarqube_host_url:
+        description: "SonarQube instance URL to use."
+        type: string
+        required: false
+        default: "http://sonarqube-prod-sonarqube.sonarqube:9000"
+      target_dir:
+        description: "Target directory where coverage file is generated."
+        type: string
+        required: false
+        default: "target"
+      args:
+        description: >
+          Additional sonar properties to use alongside the sonar-project.properties file.
+          For more language specific options, refer to https://docs.sonarqube.org/latest/analyzing-source-code/analysis-parameters/
+        type: string
+        required: false
+        default: >
+          -Dsonar.projectVersion=${{ github.sha }}
+      runner:
+        description: "Runner size to use."
+        type: string
+        required: false
+        default: "large-dind-cached"
+      quality_gate_check:
+        description: |
+          Verify the quality gate status. Setting this will fail the build in case of quality gate conditions not being met
+          Only applicable to "pull_request" event type.
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  sonarqube:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Fail if report generation enabled but artifact to download is missing
+        if: ${{ inputs.clippy_artifact_name == '' && inputs.coverage_artifact_name == '' && inputs.coverage_artifact_pattern == '' }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+              core.setFailed('At least one of clippy_artifact_name, coverage_artifact_name, or coverage_artifact_pattern must be set')
+
+      - name: Run Circle actions runner setup
+        uses: circlefin/circle-runner-setup-action@v5.7
+        with:
+          repository: ${{ inputs.repository }}
+          branch: ${{ inputs.branch }}
+          deep_clone: true
+          extra_apt_packages: libclang-dev
+
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: aws-actions/aws-secretsmanager-get-secrets@1d6311ab61b4856de027ff508aac818ddc1e141b # v2.0.7
+        with:
+          parse-json-secrets: true
+          secret-ids: |
+            /ops/sonarqube/token
+
+      - name: Download Clippy Report
+        if: ${{ inputs.clippy_artifact_name != '' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.clippy_artifact_name }}
+          path: ${{ inputs.target_dir }}
+
+      - name: Download Coverage Report (by name)
+        if: ${{ inputs.coverage_artifact_name != '' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: ${{ inputs.coverage_artifact_name }}
+          path: ${{ inputs.target_dir }}
+
+      - name: Download Coverage Reports (by pattern)
+        if: ${{ inputs.coverage_artifact_name == '' && inputs.coverage_artifact_pattern != '' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          pattern: ${{ inputs.coverage_artifact_pattern }}
+          path: ${{ inputs.target_dir }}
+          merge-multiple: true
+
+      - name: List downloaded artifacts
+        run: ls -la ${{ inputs.target_dir }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48
+
+      # Assumes sonar-project.properties file exists in the repo root with the necessary sonar properties.
+      # If you do not want to define file, call this workflow with the args input
+      - name: SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@1a6d90ebcb0e6a6b1d87e37ba693fe453195ae25 # v5.3.1
+        env:
+          SONAR_TOKEN: ${{ env._OPS_SONARQUBE_TOKEN_TOKEN }}
+          SONAR_HOST_URL: ${{ inputs.sonarqube_host_url }}
+        with:
+          args: >
+            ${{ inputs.args }}
+            -Dsonar.projectKey=${{ inputs.sonar_project_key }}
+            ${{ runner.debug == '1' && '--debug' || '' }}
+
+      - name: SonarQube Quality Gate check
+        if: ${{ inputs.quality_gate_check && github.event_name == 'pull_request' }}
+        uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
+        timeout-minutes: 2
+        env:
+          SONAR_TOKEN: ${{ env._OPS_SONARQUBE_TOKEN_TOKEN }}
+          SONAR_HOST_URL: ${{ inputs.sonarqube_host_url }}
+


### PR DESCRIPTION
Closes: #1365

Introduces a reusable SonarQube workflow that can analyze Clippy reports and coverage data.

Both `rust.yml` and `coverage.yml` now call the new `sonarqube.yml` workflow to upload their respective analysis data.

---

### PR author checklist

#### Contribution eligibility

- [ ] I am a core contributor, OR I have been explicitly assigned to the linked issue
- [ ] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and my PR complies with all requirements
- [ ] I understand that PRs not meeting these requirements will be closed without review

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
