### PR TITLE
Fix WAL actor deadlock on Append errors

### DIFF
--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -113,23 +113,27 @@ where
             let entry_type = wal_entry_type(&entry);
 
             let mut buf = Vec::new();
-            encode_entry(&entry, codec, &mut buf)?;
-
-            if !buf.is_empty() {
-                let result = log.append(&buf).map_err(Into::into);
-
-                if let Err(e) = &result {
-                    error!("ATTENTION: Failed to append entry to WAL: {e}");
+            
+            // Capture encoding result and always send a reply to prevent deadlock
+            let result = encode_entry(&entry, codec, &mut buf).and_then(|_| {
+                if !buf.is_empty() {
+                    log.append(&buf).map_err(Into::into)
                 } else {
-                    debug!(
-                        type = %entry_type, entry.size = %buf.len(), log.entries = %log.len(),
-                        "Wrote log entry"
-                    );
+                    Ok(())
                 }
+            });
 
-                if reply.send(result).is_err() {
-                    error!("Failed to send WAL append reply");
-                }
+            if let Err(e) = &result {
+                error!("ATTENTION: Failed to append entry to WAL: {e}");
+            } else if !buf.is_empty() {
+                debug!(
+                    type = %entry_type, entry.size = %buf.len(), log.entries = %log.len(),
+                    "Wrote log entry"
+                );
+            }
+
+            if reply.send(result).is_err() {
+                error!("Failed to send WAL append reply");
             }
         }
 


### PR DESCRIPTION
Closes: #1376

This PR addresses the deadlock issue in the WAL actor's `Append` handler by ensuring a reply is always sent to the caller, even when encoding fails or produces an empty buffer.

## Changes
- Modified `WalMsg::Append` handler to capture the result of `encode_entry` and unconditionally send a reply
- Empty buffers now return `Ok(())` instead of silently skipping the reply
- Preserved existing error logging behavior

## Testing
The fix prevents `ractor::call!` from blocking indefinitely in scenarios where:
1. `encode_entry()` returns an error
2. The encoded buffer is empty
