### PR TITLE
docs(CCHAIN-793): ADR for Proof-of-Validator protocol

### DIFF
--- a/docs/architecture/adr-006-proof-of-validator.md
+++ b/docs/architecture/adr-006-proof-of-validator.md
@@ -23,9 +23,6 @@ Knowing which peers are validators enables better decisions about connection man
 
 This protocol operates as an independent module. It receives validator set updates from an external component (e.g., the application layer in Malachite's model) and maintains its own copy of the current validator set. The protocol is agnostic to when or how often these updates occur—it simply uses the latest validator set to evaluate validator proofs.
 
-**Implementation Note:** In Malachite, we plan to implement this protocol as part of the network layer. The 
-validator set is already broadcast to the network component.  
-
 ## Decision
 
 ### Architecture
@@ -52,6 +49,8 @@ validator set is already broadcast to the network component.
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+**Implementation Note:** In Malachite, we plan to implement this protocol as part of the network layer. The validator set is already broadcast to the network component.
 
 ### Terminology
 
@@ -319,9 +318,10 @@ Consensus keys must be securely stored.
 
 Network key theft is more probable than consensus key theft because network keys are typically stored in less secure mediums.
 If an attacker steals a validator's network private key, it can operate a replay attack:
+
+1. Retrieve a proof produced by the legit validator (via eavesdropping)
 2. Connect to a node using the legit's validator NodeId
 3. Submit the retrieved and legit validator's proof
-1. Retrieve a proof produced by the legit validator (via eavesdropping)
 4. Pass all verification checks
 
 The impact depends on which feature uses the validator information:
@@ -379,7 +379,7 @@ By including `consensus_pub_key` in the proof, we can verify the signature immed
 
 ## Status
 
-Partially implemented
+Accepted
 
 ## Consequences
 

--- a/docs/architecture/readme.md
+++ b/docs/architecture/readme.md
@@ -32,4 +32,4 @@ To suggest an ADR, please make use of the [ADR template](./adr-template.md) prov
 | [003](./adr-003-values-propagation.md)      | Propagation of Proposed Values              | Accepted              |
 | [004](./adr-004-coroutine-effect-system.md) | Coroutine-Based Effect System for Consensus | Accepted              |
 | [005](./adr-005-value-sync.md)              | Value Sync Protocol                         | Accepted              |
-| [006](./adr-006-proof-of-validator.md)      | Proof-of-Validator Protocol                 | Partially implemented |
+| [006](./adr-006-proof-of-validator.md)      | Proof-of-Validator Protocol                 | Accepted              |


### PR DESCRIPTION
Closes #1444. 

## Summary
This PR introduces ADR-006: Proof-of-Validator (PoV), a protocol that enables validator nodes to cryptographically prove their validator status to peers in the network.

### Use cases:
- Debugging and observability: classify peers as validators vs other nodes
- Connection prioritization: prefer connections to validators for reliable consensus message delivery
- Mesh formation optimization: build gossipsub mesh overlay that prioritizes validator peers
### Key design decisions:
- Store-and-re-evaluate approach: proofs are stored once and re-evaluated when validator set updates arrive
- One proof per peer lifetime: anti-spam protection with bounded storage

**Story**: [https://circlepay.atlassian.net/browse/CCHAIN-793](https://circlepay.atlassian.net/jira/software/projects/CCHAIN/boards/1021?selectedIssue=CCHAIN-793)
**Old PR**:  https://github.com/circlefin/circle-chain-consensus/pull/103