### PR TITLE
feat(test): Use cargo-nextest facilities for assigning globally unique ports

### DIFF
--- a/code/crates/test/tests/it/main.rs
+++ b/code/crates/test/tests/it/main.rs
@@ -71,12 +71,43 @@ pub struct NodeInfo {
     config_modifier: ConfigModifier<Config>,
 }
 
+fn global_slot() -> Option<usize> {
+    if let Ok(slot_str) = std::env::var("NEXTEST_TEST_GLOBAL_SLOT") {
+        Some(
+            slot_str
+                .parse::<usize>()
+                .expect("NEXTEST_TEST_GLOBAL_SLOT must be a non-negative integer"),
+        )
+    } else {
+        None
+    }
+}
+
+const BASE_PORT: usize = 5000;
+const PORTS_PER_NODE: usize = 10;
+const PORTS_PER_SLOT: usize = 200; // ample space for 20 nodes
+
 #[async_trait]
 impl NodeRunner<TestContext> for TestRunner {
     type NodeHandle = Handle;
 
     fn new<S>(id: usize, nodes: &[TestNode<TestContext, S>], params: TestParams) -> Self {
-        let base_port = 20_000 + id * 1000;
+        // Check if the NEXTEST_TEST_GLOBAL_SLOT environment variable is set.
+        //
+        // Global slot numbers are non-negative integers starting from 0 that
+        // are unique within the run for the lifetime of the test,
+        // but are reused after the test finishes.
+        //
+        // We use them to assign ports to nodes in a way that allows multiple tests
+        // to run in parallel without port conflicts.
+        let global_slot = global_slot().unwrap_or(0);
+
+        let port_offset = global_slot * PORTS_PER_SLOT + id * PORTS_PER_NODE;
+        let base_port = BASE_PORT + port_offset;
+
+        if base_port > 60000 {
+            panic!("Calculated port {base_port} is too high. Reduce concurrency or port spacing.");
+        }
 
         let (validators, private_keys) = make_validators(nodes, &params);
         let validator_set = ValidatorSet::new(validators);


### PR DESCRIPTION
This allows running the integration test suite locally in parallel:

```
$ cargo nextest run -p informalsystems-malachitebft-test --test it --jobs 16
```