### PR TITLE
test: Add more polka/commit certificate verification tests

### DIFF
--- a/code/crates/test/tests/unit/certificates/commit.rs
+++ b/code/crates/test/tests/unit/certificates/commit.rs
@@ -205,3 +205,267 @@ fn valid_extended_commit_certificate() {
         .with_votes(1..5, VoteType::Precommit) // validator 1 not needed
         .expect_valid();
 }
+
+// ============================================================================
+// Security-focused tests: address spoofing, signature replay, validator set
+// mismatch, and quorum boundary conditions.
+// ============================================================================
+
+/// Address spoofing attack: a spoofed signature claims to be from a high-VP validator
+/// but was actually signed by a different validator's key. Malachite looks up validators
+/// by address and verifies against the looked-up validator's public key, so the spoofed
+/// signature fails verification and contributes no voting power.
+#[test]
+fn commit_certificate_address_spoofing_attack() {
+    // Validators: [10, 90]. Spoofed sig claims to be validator 1 (VP=90)
+    // but is signed by validator 0's key. Signature fails → VP counted = 0.
+    CertificateTest::<Commit>::new()
+        .with_validators([10, 90])
+        .with_spoofed_address_vote(1, 0, VoteType::Precommit) // claims idx 1, signed by idx 0
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        });
+}
+
+/// Address spoofing mixed with valid votes: legitimate votes contribute their VP,
+/// but the spoofed vote contributes nothing.
+#[test]
+fn commit_certificate_address_spoofing_with_valid_votes() {
+    // Validators: [10, 20, 30, 40]. Validators 0-1 sign legitimately (VP=30).
+    // Spoofed sig claims validator 3 (VP=40) but signed by validator 2's key.
+    // Only VP=30 counted, which is insufficient.
+    CertificateTest::<Commit>::new()
+        .with_validators([10, 20, 30, 40])
+        .with_votes(0..2, VoteType::Precommit)
+        .with_spoofed_address_vote(3, 2, VoteType::Precommit)
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 30,
+            total: 100,
+            expected: 67,
+        });
+}
+
+/// Signature replay across heights: valid precommit signatures from height 1
+/// are injected into a certificate at height 2. The verifier reconstructs votes
+/// at height 2, which doesn't match what was signed at height 1.
+#[test]
+fn commit_certificate_signature_replay_across_heights() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height_1 = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    // Sign valid precommits at height 1
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_precommit(
+                height_1,
+                round,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    // Extract signatures, inject into certificate at height 2
+    let certificate = CommitCertificate {
+        height: Height::new(2),
+        round,
+        value_id,
+        commit_signatures: votes
+            .iter()
+            .map(|v| CommitSignature::new(v.message.validator_address, v.signature.clone()))
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_commit_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Signature replay across rounds: valid precommit signatures from round 0
+/// are injected into a certificate at round 1.
+#[test]
+fn commit_certificate_signature_replay_across_rounds() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round_0 = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    // Sign valid precommits at round 0
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_precommit(
+                height,
+                round_0,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    // Inject into certificate at round 1
+    let certificate = CommitCertificate {
+        height,
+        round: Round::new(1),
+        value_id,
+        commit_signatures: votes
+            .iter()
+            .map(|v| CommitSignature::new(v.message.validator_address, v.signature.clone()))
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_commit_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Signature replay across values: valid precommit signatures for value 42
+/// are injected into a certificate for value 99.
+#[test]
+fn commit_certificate_signature_replay_across_values() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+
+    // Sign valid precommits for value 42
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_precommit(
+                height,
+                round,
+                NilOrVal::Val(ValueId::new(42)),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    // Inject into certificate for value 99
+    let certificate = CommitCertificate {
+        height,
+        round,
+        value_id: ValueId::new(99),
+        commit_signatures: votes
+            .iter()
+            .map(|v| CommitSignature::new(v.message.validator_address, v.signature.clone()))
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_commit_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Validator set mismatch: signatures from validator set A are verified
+/// against validator set B. All addresses are unknown.
+#[test]
+fn commit_certificate_validator_set_mismatch() {
+    let (validators_a, signers_a) = make_validators([25, 25, 25, 25], 0xAAAA);
+    let (validators_b, _) = make_validators([25, 25, 25, 25], 0xBBBB);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    // Sign with set A's keys
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers_a[i].sign_vote(ctx.new_precommit(
+                height,
+                round,
+                NilOrVal::Val(value_id),
+                validators_a[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = CommitCertificate::new(height, round, value_id, votes);
+
+    // Verify against set B
+    let validator_set_b = ValidatorSet::new(validators_b.to_vec());
+    let result = block_on(signers_a[0].verify_commit_certificate(
+        &ctx,
+        &certificate,
+        &validator_set_b,
+        ThresholdParams::default(),
+    ));
+    assert!(matches!(result, Err(CertificateError::UnknownValidator(_))));
+}
+
+/// Quorum boundary: exactly 2/3 is NOT sufficient because the check is strict >
+/// (signed * 3 > total * 2). With validators [1, 1, 1] and 2 of 3 signing:
+/// 2*3=6 > 3*2=6 is false, so the quorum is not met.
+#[test]
+fn commit_certificate_quorum_boundary_exact_two_thirds_insufficient() {
+    CertificateTest::<Commit>::new()
+        .with_validators([1, 1, 1])
+        .with_votes(0..2, VoteType::Precommit) // VP=2 out of 3
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 2,
+            total: 3,
+            expected: 3,
+        });
+}
+
+/// Quorum boundary: just above 2/3. With validators [34, 33, 33] and all signing:
+/// 100*3=300 > 100*2=200, yes → valid. Also signing just [0, 1] (VP=67):
+/// 67*3=201 > 100*2=200, yes → valid.
+#[test]
+fn commit_certificate_quorum_boundary_just_above_two_thirds_sufficient() {
+    // All three sign (VP=100)
+    CertificateTest::<Commit>::new()
+        .with_validators([34, 33, 33])
+        .with_votes(0..3, VoteType::Precommit)
+        .expect_valid();
+
+    // Only validators 0 and 1 sign (VP=67)
+    CertificateTest::<Commit>::new()
+        .with_validators([34, 33, 33])
+        .with_votes(0..2, VoteType::Precommit)
+        .expect_valid();
+}

--- a/code/crates/test/tests/unit/certificates/polka.rs
+++ b/code/crates/test/tests/unit/certificates/polka.rs
@@ -1,5 +1,6 @@
 use futures::executor::block_on;
 use malachitebft_core_types::PolkaCertificate;
+use malachitebft_signing::SigningProviderExt;
 
 use super::{make_validators, types::*, CertificateBuilder, CertificateTest, DEFAULT_SEED};
 
@@ -194,4 +195,285 @@ fn polka_certificate_with_mixed_valid_and_invalid_votes() {
             total: 100,
             expected: 67,
         });
+}
+
+// ============================================================================
+// Security-focused tests: address spoofing, signature replay, cross-type replay,
+// validator set mismatch, and quorum boundary conditions.
+// ============================================================================
+
+/// Address spoofing attack: a spoofed signature claims to be from a high-VP validator
+/// but was actually signed by a different validator's key.
+#[test]
+fn polka_certificate_address_spoofing_attack() {
+    CertificateTest::<Polka>::new()
+        .with_validators([10, 90])
+        .with_spoofed_address_vote(1, 0, VoteType::Prevote)
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        });
+}
+
+/// Signature replay across heights: valid prevote signatures from height 1
+/// are injected into a polka certificate at height 2.
+#[test]
+fn polka_certificate_signature_replay_across_heights() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height_1 = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_prevote(
+                height_1,
+                round,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = PolkaCertificate {
+        height: Height::new(2),
+        round,
+        value_id,
+        polka_signatures: votes
+            .iter()
+            .map(|v| PolkaSignature::new(v.message.validator_address, v.signature.clone()))
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_polka_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Signature replay across rounds: valid prevote signatures from round 0
+/// are injected into a polka certificate at round 1.
+#[test]
+fn polka_certificate_signature_replay_across_rounds() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round_0 = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_prevote(
+                height,
+                round_0,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = PolkaCertificate {
+        height,
+        round: Round::new(1),
+        value_id,
+        polka_signatures: votes
+            .iter()
+            .map(|v| PolkaSignature::new(v.message.validator_address, v.signature.clone()))
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_polka_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Signature replay across values: valid prevote signatures for value 42
+/// are injected into a polka certificate for value 99.
+#[test]
+fn polka_certificate_signature_replay_across_values() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_prevote(
+                height,
+                round,
+                NilOrVal::Val(ValueId::new(42)),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = PolkaCertificate {
+        height,
+        round,
+        value_id: ValueId::new(99),
+        polka_signatures: votes
+            .iter()
+            .map(|v| PolkaSignature::new(v.message.validator_address, v.signature.clone()))
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_polka_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Cross-type replay: valid precommit signatures are injected into a polka
+/// (prevote) certificate. The verifier reconstructs prevotes, but the signatures
+/// were over precommit data, so verification fails.
+#[test]
+fn polka_certificate_cross_type_replay_from_precommit() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    // Sign valid precommits
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_precommit(
+                height,
+                round,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    // Inject precommit signatures into a polka (prevote) certificate
+    let certificate = PolkaCertificate {
+        height,
+        round,
+        value_id,
+        polka_signatures: votes
+            .iter()
+            .map(|v| PolkaSignature::new(v.message.validator_address, v.signature.clone()))
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_polka_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Validator set mismatch: signatures from validator set A are verified
+/// against validator set B. All addresses are unknown.
+#[test]
+fn polka_certificate_validator_set_mismatch() {
+    let (validators_a, signers_a) = make_validators([25, 25, 25, 25], 0xAAAA);
+    let (validators_b, _) = make_validators([25, 25, 25, 25], 0xBBBB);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers_a[i].sign_vote(ctx.new_prevote(
+                height,
+                round,
+                NilOrVal::Val(value_id),
+                validators_a[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = PolkaCertificate::new(height, round, value_id, votes);
+
+    let validator_set_b = ValidatorSet::new(validators_b.to_vec());
+    let result = block_on(signers_a[0].verify_polka_certificate(
+        &ctx,
+        &certificate,
+        &validator_set_b,
+        ThresholdParams::default(),
+    ));
+    assert!(matches!(result, Err(CertificateError::UnknownValidator(_))));
+}
+
+/// Quorum boundary: exactly 2/3 is NOT sufficient (strict >).
+/// With validators [1, 1, 1] and 2 of 3 signing: 2*3=6 > 3*2=6 is false.
+#[test]
+fn polka_certificate_quorum_boundary_exact_two_thirds_insufficient() {
+    CertificateTest::<Polka>::new()
+        .with_validators([1, 1, 1])
+        .with_votes(0..2, VoteType::Prevote)
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 2,
+            total: 3,
+            expected: 3,
+        });
+}
+
+/// Quorum boundary: just above 2/3 is sufficient.
+/// With validators [34, 33, 33], signing [0, 1] (VP=67): 67*3=201 > 100*2=200.
+#[test]
+fn polka_certificate_quorum_boundary_just_above_two_thirds_sufficient() {
+    CertificateTest::<Polka>::new()
+        .with_validators([34, 33, 33])
+        .with_votes(0..3, VoteType::Prevote)
+        .expect_valid();
+
+    CertificateTest::<Polka>::new()
+        .with_validators([34, 33, 33])
+        .with_votes(0..2, VoteType::Prevote)
+        .expect_valid();
 }

--- a/code/crates/test/tests/unit/certificates/round.rs
+++ b/code/crates/test/tests/unit/certificates/round.rs
@@ -1,5 +1,6 @@
 use futures::executor::block_on;
 use malachitebft_core_types::RoundCertificate;
+use malachitebft_signing::SigningProviderExt;
 
 use super::{make_validators, types::*, CertificateBuilder, CertificateTest, DEFAULT_SEED};
 
@@ -470,4 +471,609 @@ fn round_certificate_with_mixed_valid_and_invalid_votes() {
             total: 100,
             expected: 67,
         });
+}
+
+// ============================================================================
+// Security-focused tests: address spoofing, signature replay, cross-type replay,
+// validator set mismatch, and quorum boundary conditions.
+// ============================================================================
+
+/// Address spoofing in a SkipRound certificate (1/3+ threshold).
+#[test]
+fn round_skip_certificate_address_spoofing_attack() {
+    // Validators: [10, 90]. Spoofed sig claims validator 1 (VP=90)
+    // but is signed by validator 0's key. Sig fails → VP=0.
+    CertificateTest::<RoundSkip>::new()
+        .with_validators([10, 90])
+        .with_spoofed_address_vote(1, 0, VoteType::Prevote)
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 34,
+        });
+}
+
+/// Address spoofing in a PrecommitRound certificate (2/3+ threshold).
+#[test]
+fn round_precommit_certificate_address_spoofing_attack() {
+    CertificateTest::<RoundPrecommit>::new()
+        .with_validators([10, 90])
+        .with_spoofed_address_vote(1, 0, VoteType::Precommit)
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        });
+}
+
+/// Signature replay across heights in a SkipRound certificate.
+#[test]
+fn round_skip_certificate_signature_replay_across_heights() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height_1 = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    // Sign valid prevotes at height 1
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_prevote(
+                height_1,
+                round,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    // Inject into certificate at height 2
+    let certificate = RoundCertificate {
+        height: Height::new(2),
+        round,
+        cert_type: RoundCertificateType::Skip,
+        round_signatures: votes
+            .iter()
+            .map(|v| {
+                RoundSignature::new(
+                    VoteType::Prevote,
+                    NilOrVal::Val(value_id),
+                    v.message.validator_address,
+                    v.signature.clone(),
+                )
+            })
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 34,
+        })
+    );
+}
+
+/// Signature replay across heights in a PrecommitRound certificate.
+#[test]
+fn round_precommit_certificate_signature_replay_across_heights() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height_1 = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_precommit(
+                height_1,
+                round,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = RoundCertificate {
+        height: Height::new(2),
+        round,
+        cert_type: RoundCertificateType::Precommit,
+        round_signatures: votes
+            .iter()
+            .map(|v| {
+                RoundSignature::new(
+                    VoteType::Precommit,
+                    NilOrVal::Val(value_id),
+                    v.message.validator_address,
+                    v.signature.clone(),
+                )
+            })
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Signature replay across rounds in a SkipRound certificate.
+#[test]
+fn round_skip_certificate_signature_replay_across_rounds() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round_0 = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_prevote(
+                height,
+                round_0,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = RoundCertificate {
+        height,
+        round: Round::new(1),
+        cert_type: RoundCertificateType::Skip,
+        round_signatures: votes
+            .iter()
+            .map(|v| {
+                RoundSignature::new(
+                    VoteType::Prevote,
+                    NilOrVal::Val(value_id),
+                    v.message.validator_address,
+                    v.signature.clone(),
+                )
+            })
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 34,
+        })
+    );
+}
+
+/// Signature replay across rounds in a PrecommitRound certificate.
+#[test]
+fn round_precommit_certificate_signature_replay_across_rounds() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round_0 = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_precommit(
+                height,
+                round_0,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = RoundCertificate {
+        height,
+        round: Round::new(1),
+        cert_type: RoundCertificateType::Precommit,
+        round_signatures: votes
+            .iter()
+            .map(|v| {
+                RoundSignature::new(
+                    VoteType::Precommit,
+                    NilOrVal::Val(value_id),
+                    v.message.validator_address,
+                    v.signature.clone(),
+                )
+            })
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Signature replay across values in a SkipRound certificate.
+/// The value_id is per-RoundSignature, so the verifier reconstructs the vote
+/// with the RoundSignature's value_id. But we put the cert at the same
+/// height/round and the signature's value_id matches what was signed, so we
+/// need to tamper the value_id in the RoundSignature to simulate a replay.
+#[test]
+fn round_skip_certificate_signature_replay_across_values() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+
+    // Sign valid prevotes for value 42
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_prevote(
+                height,
+                round,
+                NilOrVal::Val(ValueId::new(42)),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    // Inject signatures but claim they were for value 99
+    let certificate = RoundCertificate {
+        height,
+        round,
+        cert_type: RoundCertificateType::Skip,
+        round_signatures: votes
+            .iter()
+            .map(|v| {
+                RoundSignature::new(
+                    VoteType::Prevote,
+                    NilOrVal::Val(ValueId::new(99)),
+                    v.message.validator_address,
+                    v.signature.clone(),
+                )
+            })
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 34,
+        })
+    );
+}
+
+/// Signature replay across values in a PrecommitRound certificate.
+#[test]
+fn round_precommit_certificate_signature_replay_across_values() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_precommit(
+                height,
+                round,
+                NilOrVal::Val(ValueId::new(42)),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate = RoundCertificate {
+        height,
+        round,
+        cert_type: RoundCertificateType::Precommit,
+        round_signatures: votes
+            .iter()
+            .map(|v| {
+                RoundSignature::new(
+                    VoteType::Precommit,
+                    NilOrVal::Val(ValueId::new(99)),
+                    v.message.validator_address,
+                    v.signature.clone(),
+                )
+            })
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 67,
+        })
+    );
+}
+
+/// Cross-type replay in a PrecommitRound certificate: prevote signatures are
+/// injected with vote_type set to Prevote. The explicit check for
+/// `InvalidVoteType` fires before signature verification.
+#[test]
+fn round_precommit_certificate_cross_type_replay_from_prevote() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    // Sign valid prevotes
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_prevote(
+                height,
+                round,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    // Inject as Prevote-typed signatures into a Precommit certificate
+    let certificate = RoundCertificate {
+        height,
+        round,
+        cert_type: RoundCertificateType::Precommit,
+        round_signatures: votes
+            .iter()
+            .map(|v| {
+                RoundSignature::new(
+                    VoteType::Prevote,
+                    NilOrVal::Val(value_id),
+                    v.message.validator_address,
+                    v.signature.clone(),
+                )
+            })
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    // InvalidVoteType is returned for the first signature before sig verification
+    assert!(matches!(result, Err(CertificateError::InvalidVoteType(_))));
+}
+
+/// Cross-type replay in a SkipRound certificate with flipped vote type:
+/// sign as precommit but inject as RoundSignature with vote_type=Prevote.
+/// The verifier reconstructs a prevote, but the signature was over precommit
+/// data, so verification fails.
+#[test]
+fn round_skip_certificate_cross_type_replay_flipped_vote_type() {
+    let (validators, signers) = make_validators([25, 25, 25, 25], DEFAULT_SEED);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    // Sign valid precommits
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers[i].sign_vote(ctx.new_precommit(
+                height,
+                round,
+                NilOrVal::Val(value_id),
+                validators[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    // Inject with vote_type=Prevote (flipped) into a Skip certificate
+    let certificate = RoundCertificate {
+        height,
+        round,
+        cert_type: RoundCertificateType::Skip,
+        round_signatures: votes
+            .iter()
+            .map(|v| {
+                RoundSignature::new(
+                    VoteType::Prevote, // flipped from Precommit
+                    NilOrVal::Val(value_id),
+                    v.message.validator_address,
+                    v.signature.clone(),
+                )
+            })
+            .collect(),
+    };
+
+    let validator_set = ValidatorSet::new(validators.to_vec());
+    let result = block_on(signers[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set,
+        ThresholdParams::default(),
+    ));
+    assert_eq!(
+        result,
+        Err(CertificateError::NotEnoughVotingPower {
+            signed: 0,
+            total: 100,
+            expected: 34,
+        })
+    );
+}
+
+/// Validator set mismatch for SkipRound certificate.
+#[test]
+fn round_skip_certificate_validator_set_mismatch() {
+    let (validators_a, signers_a) = make_validators([25, 25, 25, 25], 0xAAAA);
+    let (validators_b, _) = make_validators([25, 25, 25, 25], 0xBBBB);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers_a[i].sign_vote(ctx.new_prevote(
+                height,
+                round,
+                NilOrVal::Val(value_id),
+                validators_a[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate =
+        RoundCertificate::new_from_votes(height, round, RoundCertificateType::Skip, votes);
+
+    let validator_set_b = ValidatorSet::new(validators_b.to_vec());
+    let result = block_on(signers_a[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set_b,
+        ThresholdParams::default(),
+    ));
+    assert!(matches!(result, Err(CertificateError::UnknownValidator(_))));
+}
+
+/// Validator set mismatch for PrecommitRound certificate.
+#[test]
+fn round_precommit_certificate_validator_set_mismatch() {
+    let (validators_a, signers_a) = make_validators([25, 25, 25, 25], 0xAAAA);
+    let (validators_b, _) = make_validators([25, 25, 25, 25], 0xBBBB);
+    let ctx = TestContext::new();
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value_id = ValueId::new(42);
+
+    let votes: Vec<_> = (0..4)
+        .map(|i| {
+            block_on(signers_a[i].sign_vote(ctx.new_precommit(
+                height,
+                round,
+                NilOrVal::Val(value_id),
+                validators_a[i].address,
+            )))
+            .unwrap()
+        })
+        .collect();
+
+    let certificate =
+        RoundCertificate::new_from_votes(height, round, RoundCertificateType::Precommit, votes);
+
+    let validator_set_b = ValidatorSet::new(validators_b.to_vec());
+    let result = block_on(signers_a[0].verify_round_certificate(
+        &ctx,
+        &certificate,
+        &validator_set_b,
+        ThresholdParams::default(),
+    ));
+    assert!(matches!(result, Err(CertificateError::UnknownValidator(_))));
+}
+
+/// Quorum boundary for SkipRound: exactly 1/3 is NOT sufficient (strict >).
+/// With validators [1, 1, 1] and 1 of 3 signing: 1*3=3 > 3*1=3 is false.
+#[test]
+fn round_skip_certificate_quorum_boundary_exact_one_third_insufficient() {
+    CertificateTest::<RoundSkip>::new()
+        .with_validators([1, 1, 1])
+        .with_votes(0..1, VoteType::Prevote)
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 1,
+            total: 3,
+            expected: 2,
+        });
+}
+
+/// Quorum boundary for SkipRound: just above 1/3 is sufficient.
+/// With validators [1, 1, 1] and 2 of 3 signing: 2*3=6 > 3*1=3, yes.
+#[test]
+fn round_skip_certificate_quorum_boundary_just_above_one_third_sufficient() {
+    CertificateTest::<RoundSkip>::new()
+        .with_validators([1, 1, 1])
+        .with_votes(0..2, VoteType::Prevote)
+        .expect_valid();
+}
+
+/// Quorum boundary for PrecommitRound: exactly 2/3 is NOT sufficient (strict >).
+/// With validators [1, 1, 1] and 2 of 3 signing: 2*3=6 > 3*2=6 is false.
+#[test]
+fn round_precommit_certificate_quorum_boundary_exact_two_thirds_insufficient() {
+    CertificateTest::<RoundPrecommit>::new()
+        .with_validators([1, 1, 1])
+        .with_votes(0..2, VoteType::Precommit)
+        .expect_error(CertificateError::NotEnoughVotingPower {
+            signed: 2,
+            total: 3,
+            expected: 3,
+        });
+}
+
+/// Quorum boundary for PrecommitRound: just above 2/3 is sufficient.
+/// With validators [34, 33, 33], signing [0, 1] (VP=67): 67*3=201 > 100*2=200.
+#[test]
+fn round_precommit_certificate_quorum_boundary_just_above_two_thirds_sufficient() {
+    CertificateTest::<RoundPrecommit>::new()
+        .with_validators([34, 33, 33])
+        .with_votes(0..3, VoteType::Precommit)
+        .expect_valid();
+
+    CertificateTest::<RoundPrecommit>::new()
+        .with_validators([34, 33, 33])
+        .with_votes(0..2, VoteType::Precommit)
+        .expect_valid();
 }


### PR DESCRIPTION
Add 32 new tests covering address spoofing, signature replay (across heights, rounds, and values), cross-type replay, validator set mismatch, and quorum boundary conditions for commit, polka, and round certificates.