### PR TITLE
fix(metrics): Invalidate old discovered_peers metric entries when address changes

### DIFF
--- a/code/crates/network/src/metrics.rs
+++ b/code/crates/network/src/metrics.rs
@@ -57,6 +57,15 @@ impl PeerInfo {
             },
         }
     }
+
+    /// Check if label-relevant fields match another PeerInfo.
+    /// Used to determine if metrics need to be updated (stale marking).
+    pub(crate) fn labels_match(&self, other: &PeerInfo) -> bool {
+        self.moniker == other.moniker
+            && self.address == other.address
+            && self.peer_type == other.peer_type
+            && self.consensus_address == other.consensus_address
+    }
 }
 
 /// Labels for local node info (peer_id and listen address)
@@ -213,55 +222,57 @@ impl Metrics {
         }
     }
 
-    pub(crate) fn record_peer_info(&mut self, peer_id: &PeerId, peer_info: &PeerInfo) {
-        // Check if peer already has a slot (re-identification case)
-        if self.peer_slots.contains(peer_id) {
-            // Peer already tracked in metrics, labels are already set
-            // Score will be updated by update_peer_info
-            return;
-        }
-
-        // Try to assign a new slot (subject to 100 slot limit)
-        let Some(slot) = self.peer_slots.assign(*peer_id) else {
-            // Failed to assign slot (all slots full)
-            warn!("No available metric slots for peer {peer_id}");
-            return;
+    /// Record metrics for a new peer (assigns slot if needed).
+    pub(crate) fn record_new_peer(&mut self, peer_id: &PeerId, peer_info: &PeerInfo) {
+        let slot = if let Some(existing_slot) = self.peer_slots.get(peer_id) {
+            existing_slot
+        } else {
+            let Some(new_slot) = self.peer_slots.assign(*peer_id) else {
+                warn!("No available metric slots for peer {peer_id}");
+                return;
+            };
+            new_slot
         };
 
-        // Create labels for initial metrics (score will be updated by update_peer_info)
         let labels = peer_info.to_labels(peer_id, slot);
-        self.discovered_peers.get_or_create(&labels).set(0);
+        self.discovered_peers
+            .get_or_create(&labels)
+            .set(peer_info.score as i64);
     }
 
-    /// Update peer type in metrics (e.g., when validator set changes)
-    /// Note: Due to Prometheus label immutability, old metrics with the old peer_type will remain stale
-    pub(crate) fn update_peer_type(
+    /// Update metrics for an existing peer when labels may have changed.
+    ///
+    /// Compares old and new peer info:
+    /// - If labels changed: marks old entry stale, creates new entry
+    /// - If labels unchanged: just updates the score
+    ///
+    /// Returns true if labels changed.
+    pub(crate) fn update_peer_labels(
         &mut self,
         peer_id: &PeerId,
         old_peer_info: &PeerInfo,
-        new_peer_type: PeerType,
-    ) {
-        if let Some(slot) = self.peer_slots.get(peer_id) {
-            // Mark old peer_type entry as stale
+        new_peer_info: &PeerInfo,
+    ) -> bool {
+        let Some(slot) = self.peer_slots.get(peer_id) else {
+            return false;
+        };
+
+        let labels_changed = !old_peer_info.labels_match(new_peer_info);
+
+        if labels_changed {
             let old_labels = old_peer_info.to_labels(peer_id, slot);
+            tracing::debug!(%peer_id, ?old_labels, "Marking peer metric stale");
             self.discovered_peers
                 .get_or_create(&old_labels)
                 .set(i64::MIN);
-
-            // Create new peer_info with updated type for new labels
-            let mut new_peer_info = old_peer_info.clone();
-            new_peer_info.peer_type = new_peer_type;
-
-            // Create new metric entry with updated peer_type
-            let new_labels = new_peer_info.to_labels(peer_id, slot);
-            self.discovered_peers
-                .get_or_create(&new_labels)
-                .set(old_peer_info.score as i64);
-
-            debug!(
-                "Updated peer type for {peer_id} from {:?} to {:?}",
-                old_peer_info.peer_type, new_peer_type
-            );
         }
+
+        // Create/update metric entry with current labels
+        let new_labels = new_peer_info.to_labels(peer_id, slot);
+        self.discovered_peers
+            .get_or_create(&new_labels)
+            .set(new_peer_info.score as i64);
+
+        labels_changed
     }
 }

--- a/code/crates/network/src/utils.rs
+++ b/code/crates/network/src/utils.rs
@@ -30,6 +30,7 @@ where
     }
 
     /// Checks if a entry has an assigned slot.
+    #[cfg(test)]
     pub fn contains(&self, entry: &T) -> bool {
         self.get(entry).is_some()
     }


### PR DESCRIPTION

Closes: #XXX

## Summary
Fix stale `discovered_peers` entries on address change.
Note: this is cherry-picked from validator-proof branch, 61ac08cd967e8d7141c027b883bbd22ddf325899

## Problem

When a peer connects via multiple connections (e.g., one inbound, one outbound), each connection has a different source address (`/tcp/52110` vs `/tcp/27000`).
The `update_peer_metrics` tick writes a metric entry using the current `PeerInfo` labels, which include the address. When `update_peer` is called for a second connection and updates the address in `PeerInfo`, the old-address metric entry is never invalidated and left behind with a valid score

Later, when `reclassify_peers` changes the peer's type (e.g., `validator` to `persistent_peer`), it only marks stale the entry matching the current address. The old-address entry with `peer_type="validator"` survives with a valid score, making the peer appear as a validator in metrics even after it was rotated out.

## Fix

Replace `update_peer` logic that silently overwrote `PeerInfo` with a path that:
1. Clones the old `PeerInfo` before updating fields
2. Calls `update_peer_labels(old, new)` which compares all label fields via `labels_match()`
3. If any label changed (address, type, moniker, consensus_address): marks the old entry
   stale (`i64::MIN`) before creating the new one

This ensures at most one active metric entry per peer at any time.

---

### PR author checklist

#### Contribution eligibility

- [ ] I am a core contributor, OR I have been explicitly assigned to the linked issue
- [ ] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and my PR complies with all requirements
- [ ] I understand that PRs not meeting these requirements will be closed without review

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
