### PR TITLE
fix: Revert `libp2p-scatter` update

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,7 +41,6 @@
 - Add network metrics for peer identification and tracking
 - Add transport level connection limits
 - Limit the number of peers that can connect from same IP address
-- Update `libp2p-scatter` to v0.4.0-rc.1 ([#1473](https://github.com/circlefin/malachite/pull/1473))
 
 ### `signing`
 - Implement `SigningProvider` for `Arc<T>` where `T: SigningProvider`

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -3318,11 +3318,10 @@ dependencies = [
 
 [[package]]
 name = "libp2p-scatter"
-version = "0.4.0-rc.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429c48df0e3d76f2d86dee257822ec1c109cfd22481462bd7d307a9522fec249"
+checksum = "ea402c419f99e6013d5b12f97c5a1a1abe4aca285844b01b0ed96deab11f0b6e"
 dependencies = [
- "asynchronous-codec",
  "bytes",
  "fnv",
  "futures",
@@ -5822,10 +5821,6 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
-dependencies = [
- "asynchronous-codec",
- "bytes",
-]
 
 [[package]]
 name = "untrusted"

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -144,7 +144,7 @@ itertools          = "0.14"
 itf                = "0.2.3"
 libp2p             = { version = "0.56.0", features = ["macros", "identify", "tokio", "ed25519", "ecdsa", "tcp", "quic", "noise", "yamux", "gossipsub", "dns", "ping", "metrics", "request-response", "cbor", "serde", "kad"] }
 libp2p-identity    = "0.2.12"
-libp2p-broadcast   = { version = "0.4.0-rc.1", features = ["metrics"], package = "libp2p-scatter" }
+libp2p-broadcast   = { version = "0.3.0", package = "libp2p-scatter" }
 libp2p-gossipsub   = { version = "0.49.0", features = ["metrics"] }
 multiaddr          = "0.18.2"
 multihash          = { version = "0.19.3", default-features = false }

--- a/code/crates/app/src/spawn.rs
+++ b/code/crates/app/src/spawn.rs
@@ -268,7 +268,6 @@ fn make_network_config(cfg: &ConsensusConfig, value_sync_cfg: &ValueSyncConfig) 
             discovery_kad: cfg.p2p.protocol_names.discovery_kad.clone(),
             discovery_regres: cfg.p2p.protocol_names.discovery_regres.clone(),
             sync: cfg.p2p.protocol_names.sync.clone(),
-            broadcast: cfg.p2p.protocol_names.broadcast.clone(),
         },
     }
 }

--- a/code/crates/config/src/lib.rs
+++ b/code/crates/config/src/lib.rs
@@ -12,10 +12,12 @@ mod utils;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProtocolNames {
     pub consensus: String,
+
     pub discovery_kad: String,
+
     pub discovery_regres: String,
+
     pub sync: String,
-    pub broadcast: String,
 }
 
 impl Default for ProtocolNames {
@@ -25,7 +27,6 @@ impl Default for ProtocolNames {
             discovery_kad: "/malachitebft-discovery/kad/v1beta1".to_string(),
             discovery_regres: "/malachitebft-discovery/reqres/v1beta1".to_string(),
             sync: "/malachitebft-sync/v1beta1".to_string(),
-            broadcast: "/malachitebft-broadcast/v1beta1".to_string(),
         }
     }
 }
@@ -867,7 +868,6 @@ mod tests {
             discovery_kad: "/custom-discovery/kad/v1".to_string(),
             discovery_regres: "/custom-discovery/reqres/v1".to_string(),
             sync: "/custom-sync/v1".to_string(),
-            broadcast: "/custom-broadcast/v1".to_string(),
         };
 
         let json = serde_json::to_string(&protocol_names).unwrap();
@@ -890,7 +890,6 @@ mod tests {
             discovery_kad: "/test-network/discovery/kad/v1".to_string(),
             discovery_regres: "/test-network/discovery/reqres/v1".to_string(),
             sync: "/test-network/sync/v1".to_string(),
-            broadcast: "/test-network/broadcast/v1".to_string(),
         };
 
         let config_with_custom = P2pConfig {
@@ -924,7 +923,6 @@ mod tests {
         discovery_kad = "/custom-network/discovery/kad/v2"
         discovery_regres = "/custom-network/discovery/reqres/v2"
         sync = "/custom-network/sync/v2"
-        broadcast = "/custom-network/broadcast/v2"
         
         [p2p.protocol]
         type = "gossipsub"
@@ -945,10 +943,6 @@ mod tests {
             "/custom-network/discovery/reqres/v2"
         );
         assert_eq!(config.p2p.protocol_names.sync, "/custom-network/sync/v2");
-        assert_eq!(
-            config.p2p.protocol_names.broadcast,
-            "/custom-network/broadcast/v2"
-        );
     }
 
     #[test]

--- a/code/crates/network/Cargo.toml
+++ b/code/crates/network/Cargo.toml
@@ -24,7 +24,7 @@ either = { workspace = true }
 eyre = { workspace = true }
 futures = { workspace = true }
 libp2p = { workspace = true }
-libp2p-broadcast = { workspace = true, features = ["metrics"] }
+libp2p-broadcast = { workspace = true }
 libp2p-gossipsub = { workspace = true, features = ["metrics"] }
 seahash = { workspace = true }
 serde = { workspace = true }

--- a/code/crates/network/src/behaviour.rs
+++ b/code/crates/network/src/behaviour.rs
@@ -2,16 +2,15 @@ use std::convert::Infallible;
 use std::time::Duration;
 
 use eyre::Result;
+use libp2p::connection_limits;
+pub use libp2p::identity::Keypair;
 use libp2p::kad::{Addresses, KBucketKey, KBucketRef};
 use libp2p::request_response::{OutboundRequestId, ResponseChannel};
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::swarm::NetworkBehaviour;
-use libp2p::{connection_limits, StreamProtocol};
 use libp2p::{gossipsub, identify, ping};
-use libp2p_broadcast as broadcast;
-
-pub use libp2p::identity::Keypair;
 pub use libp2p::{Multiaddr, PeerId};
+use libp2p_broadcast as broadcast;
 
 use malachitebft_discovery as discovery;
 use malachitebft_metrics::Registry;
@@ -241,17 +240,11 @@ impl Behaviour {
 
         let enable_broadcast = (config.pubsub_protocol.is_broadcast() && config.enable_consensus)
             || config.enable_sync;
-
         let broadcast = enable_broadcast.then(|| {
-            let protocol = StreamProtocol::try_from_owned(config.protocol_names.broadcast.clone())
-                .expect("Invalid protocol name for broadcast");
-
-            let config = broadcast::Config::default()
-                .protocol_name(protocol)
-                .max_message_size(config.pubsub_max_size);
-
             broadcast::Behaviour::new_with_metrics(
-                config,
+                broadcast::Config {
+                    max_buf_size: config.pubsub_max_size,
+                },
                 registry.sub_registry_with_prefix("broadcast"),
             )
         });

--- a/code/crates/network/src/lib.rs
+++ b/code/crates/network/src/lib.rs
@@ -60,7 +60,6 @@ pub struct ProtocolNames {
     pub discovery_kad: String,
     pub discovery_regres: String,
     pub sync: String,
-    pub broadcast: String,
 }
 
 impl Default for ProtocolNames {
@@ -70,7 +69,6 @@ impl Default for ProtocolNames {
             discovery_kad: "/malachitebft-discovery/kad/v1beta1".to_string(),
             discovery_regres: "/malachitebft-discovery/reqres/v1beta1".to_string(),
             sync: "/malachitebft-sync/v1beta1".to_string(),
-            broadcast: "/malachitebft-broadcast/v1beta1".to_string(),
         }
     }
 }

--- a/code/crates/network/src/pubsub.rs
+++ b/code/crates/network/src/pubsub.rs
@@ -51,7 +51,7 @@ pub fn publish(
         }
         PubSubProtocol::Broadcast => {
             if let Some(broadcast) = swarm.behaviour_mut().broadcast.as_mut() {
-                broadcast.broadcast(channel.to_broadcast_topic(channel_names), data);
+                broadcast.broadcast(&channel.to_broadcast_topic(channel_names), data);
             } else {
                 return Err(eyre::eyre!("Broadcast not enabled"));
             }

--- a/code/crates/starknet/host/src/spawn.rs
+++ b/code/crates/starknet/host/src/spawn.rs
@@ -293,7 +293,6 @@ async fn spawn_network_actor(
             discovery_kad: cfg.consensus.p2p.protocol_names.discovery_kad.clone(),
             discovery_regres: cfg.consensus.p2p.protocol_names.discovery_regres.clone(),
             sync: cfg.consensus.p2p.protocol_names.sync.clone(),
-            broadcast: cfg.consensus.p2p.protocol_names.broadcast.clone(),
         },
     };
 


### PR DESCRIPTION
This reverts commit 1a78a8ad0a17d14dc559e7fb5419ca928a766e12.