### PR TITLE
feat(CCHAIN-1193): Malicious node -- produce equivocations

### DIFF
--- a/code/crates/core-types/src/proposal.rs
+++ b/code/crates/core-types/src/proposal.rs
@@ -25,6 +25,9 @@ where
 
     /// Address of the validator who issued this proposal
     fn validator_address(&self) -> &Ctx::Address;
+
+    /// Return a copy of this proposal with a different value.
+    fn with_value(self, value: Ctx::Value) -> Self;
 }
 
 /// Whether or not a proposal is valid.

--- a/code/crates/core-types/src/value.rs
+++ b/code/crates/core-types/src/value.rs
@@ -89,6 +89,10 @@ where
 
     /// The ID of the value.
     fn id(&self) -> Self::Id;
+
+    /// Return a dummy/sentinel value for testing purposes.
+    /// Must differ from any real value produced by the system.
+    fn dummy() -> Self;
 }
 
 /// The possible messages used to deliver proposals

--- a/code/crates/core-types/src/vote.rs
+++ b/code/crates/core-types/src/vote.rs
@@ -53,4 +53,7 @@ where
 
     /// Extend this vote with an extension, overriding any existing extension.
     fn extend(self, extension: SignedExtension<Ctx>) -> Self;
+
+    /// Return a copy of this vote with a different value.
+    fn with_value(self, value: NilOrVal<<Ctx::Value as Value>::Id>) -> Self;
 }

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -19,8 +19,8 @@ use malachitebft_core_consensus::{
     Effect, LivenessMsg, PeerId, Resumable, Resume, SignedConsensusMsg, VoteExtensionError,
 };
 use malachitebft_core_types::{
-    Context, Proposal, Round, Timeout, TimeoutKind, Timeouts, ValidatorSet, Validity, Value,
-    ValueId, ValueOrigin, ValueResponse as CoreValueResponse, Vote,
+    Context, NilOrVal, Proposal, Round, Timeout, TimeoutKind, Timeouts, ValidatorSet, Validity,
+    Value, ValueId, ValueOrigin, ValueResponse as CoreValueResponse, Vote,
 };
 use malachitebft_metrics::Metrics;
 use malachitebft_signing::{SigningProvider, SigningProviderExt};
@@ -1140,8 +1140,36 @@ where
                 self.tx_event.send(|| Event::Published(msg.clone()));
 
                 self.network
-                    .cast(NetworkMsg::PublishConsensusMsg(msg))
+                    .cast(NetworkMsg::PublishConsensusMsg(msg.clone()))
                     .map_err(|e| eyre!("Error when broadcasting consensus message: {e:?}"))?;
+
+                // TESTING ONLY: send conflicting messages to trigger equivocation detection
+                if std::env::var("TEST_ONLY_MALICIOUS_NODE").as_deref() == Ok("true") {
+                    match &msg {
+                        SignedConsensusMsg::Vote(signed_vote) => {
+                            // Send a conflicting nil vote to trigger vote equivocation
+                            if signed_vote.message.value().is_val() {
+                                let conflicting = signed_vote.message.clone().with_value(NilOrVal::Nil);
+                                if let Ok(signed) = self.signing_provider.sign_vote(conflicting).await {
+                                    let _ = self.network.cast(NetworkMsg::PublishConsensusMsg(
+                                        SignedConsensusMsg::Vote(signed),
+                                    ));
+                                }
+                            }
+                        }
+                        SignedConsensusMsg::Proposal(signed_proposal) => {
+                            // Send a conflicting proposal with a dummy value to trigger
+                            // double proposal detection on honest nodes.
+                            let bad_proposal = signed_proposal.message.clone()
+                                .with_value(<<Ctx as Context>::Value as Value>::dummy());
+                            if let Ok(signed) = self.signing_provider.sign_proposal(bad_proposal).await {
+                                let _ = self.network.cast(NetworkMsg::PublishConsensusMsg(
+                                    SignedConsensusMsg::Proposal(signed),
+                                ));
+                            }
+                        }
+                    }
+                }
 
                 Ok(r.resume_with(()))
             }

--- a/code/crates/starknet/p2p-types/src/context/impls.rs
+++ b/code/crates/starknet/p2p-types/src/context/impls.rs
@@ -41,6 +41,11 @@ impl common::Proposal<MockContext> for Proposal {
     fn validator_address(&self) -> &Address {
         &self.proposer
     }
+
+    fn with_value(mut self, value: Hash) -> Self {
+        self.value_id = value;
+        self
+    }
 }
 
 impl common::Vote<MockContext> for Vote {
@@ -78,6 +83,11 @@ impl common::Vote<MockContext> for Vote {
 
     fn take_extension(&mut self) -> Option<SignedExtension<MockContext>> {
         None
+    }
+
+    fn with_value(mut self, value: NilOrVal<Hash>) -> Self {
+        self.block_hash = value;
+        self
     }
 }
 

--- a/code/crates/starknet/p2p-types/src/hash.rs
+++ b/code/crates/starknet/p2p-types/src/hash.rs
@@ -18,6 +18,10 @@ impl malachitebft_core_types::Value for BlockHash {
     fn id(&self) -> Self::Id {
         *self
     }
+
+    fn dummy() -> Self {
+        Self::new([0xBA; 32])
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/code/crates/test/src/proposal.rs
+++ b/code/crates/test/src/proposal.rs
@@ -64,6 +64,11 @@ impl malachitebft_core_types::Proposal<TestContext> for Proposal {
     fn validator_address(&self) -> &Address {
         &self.validator_address
     }
+
+    fn with_value(mut self, value: Value) -> Self {
+        self.value = value;
+        self
+    }
 }
 
 impl Protobuf for Proposal {

--- a/code/crates/test/src/value.rs
+++ b/code/crates/test/src/value.rs
@@ -88,6 +88,10 @@ impl malachitebft_core_types::Value for Value {
     fn id(&self) -> ValueId {
         self.id()
     }
+
+    fn dummy() -> Self {
+        Self::new(u64::MAX)
+    }
 }
 
 impl Protobuf for Value {

--- a/code/crates/test/src/vote.rs
+++ b/code/crates/test/src/vote.rs
@@ -104,6 +104,11 @@ impl malachitebft_core_types::Vote<TestContext> for Vote {
             ..self
         }
     }
+
+    fn with_value(mut self, value: NilOrVal<ValueId>) -> Self {
+        self.value = value;
+        self
+    }
 }
 
 impl Protobuf for Vote {


### PR DESCRIPTION
Closes: #1518

This PR introduces all kinds of equivocation. The behavior is hidden behind environment variable `TEST_ONLY_MALICIOUS_NODE`. This should NEVER be set in production.

The effect of this change is to produce all three types of equivocation in the network, where we can observe them in the logs, and RPC methods.

This PR will be reverted once the needed data has been produced on `devnet`


---

### PR author checklist

#### Contribution eligibility

- [ ] I am a core contributor, OR I have been explicitly assigned to the linked issue
- [ ] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and my PR complies with all requirements
- [ ] I understand that PRs not meeting these requirements will be closed without review

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
