### PR TITLE
fix(sync): reject sync responses with non-contiguous heights

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,7 @@
 - Remove signing of proposal parts
 
 ### `sync`
+- Reject sync responses with non-contiguous certificate heights ([#1541](https://github.com/circlefin/malachite/issues/1541))
 - Fix partial range request not being tracked in pending requests
 - Initial random (fixed) period adjustment in sync status ticker
 - Refactor sync actor to notify consensus of sync responses

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -149,7 +149,28 @@ where
         return on_invalid_value_response(co, state, metrics, request_id, peer_id).await;
     }
 
+    if !validate_value_response_heights::<Ctx>(&response) {
+        warn!(
+            %request_id, %peer_id,
+            "Response contains non-contiguous heights"
+        );
+
+        return on_invalid_value_response(co, state, metrics, request_id, peer_id).await;
+    }
+
     on_valid_value_response(co, state, metrics, request_id, peer_id, response).await
+}
+
+/// Validate that each value in the response has the expected height,
+/// ie. heights are contiguous starting from `start_height`.
+fn validate_value_response_heights<Ctx>(response: &ValueResponse<Ctx>) -> bool
+where
+    Ctx: Context,
+{
+    response.values.iter().enumerate().all(|(i, value)| {
+        let expected = response.start_height.increment_by(i as u64);
+        value.height() == expected
+    })
 }
 
 pub async fn on_send_status_update<Ctx>(
@@ -1255,6 +1276,74 @@ mod tests {
         assert_eq!(clamped, tip_height..=tip_height);
     }
 
+    #[test]
+    fn test_validate_value_response_heights() {
+        let validate = validate_value_response_heights::<TestContext>;
+
+        // Valid: contiguous heights 5, 6, 7
+        let response = ValueResponse::new(
+            Height::new(5),
+            vec![
+                make_raw_decided_value(5),
+                make_raw_decided_value(6),
+                make_raw_decided_value(7),
+            ],
+        );
+        assert!(validate(&response));
+
+        // Valid: single value
+        let response = ValueResponse::new(Height::new(1), vec![make_raw_decided_value(1)]);
+        assert!(validate(&response));
+
+        // Valid: empty response
+        let response = ValueResponse::new(Height::new(1), vec![]);
+        assert!(validate(&response));
+
+        // Invalid: gap in heights (1, 2, 5 instead of 1, 2, 3)
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(1),
+                make_raw_decided_value(2),
+                make_raw_decided_value(5),
+            ],
+        );
+        assert!(!validate(&response));
+
+        // Invalid: duplicate heights (1, 1, 2 instead of 1, 2, 3)
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(1),
+                make_raw_decided_value(1),
+                make_raw_decided_value(2),
+            ],
+        );
+        assert!(!validate(&response));
+
+        // Invalid: first value doesn't match start_height
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(2),
+                make_raw_decided_value(3),
+                make_raw_decided_value(4),
+            ],
+        );
+        assert!(!validate(&response));
+
+        // Invalid: reversed order (3, 2, 1 instead of 1, 2, 3)
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(3),
+                make_raw_decided_value(2),
+                make_raw_decided_value(1),
+            ],
+        );
+        assert!(!validate(&response));
+    }
+
     fn make_raw_decided_value(height: u64) -> RawDecidedValue<TestContext> {
         RawDecidedValue {
             value_bytes: Bytes::new(),
@@ -1269,10 +1358,6 @@ mod tests {
 
     /// Test that a non-contiguous sync response (e.g., request 1..=10, get 1,2,5..12)
     /// is rejected by the sync state machine and triggers a re-request from another peer.
-    ///
-    /// BUG: Without contiguity validation, the response is incorrectly accepted
-    /// and forwarded to consensus. Consensus will get stuck when it advances to
-    /// the missing heights (3, 4) and finds nothing in the queue.
     #[test]
     fn test_non_contiguous_response_rejected_by_sync_handler() {
         let peer_a = PeerId::random();
@@ -1360,16 +1445,13 @@ mod tests {
             }
         }
 
-        // BUG: Currently the response is accepted (ProcessValueResponse emitted)
-        // instead of being rejected (SendValueRequest emitted).
-        // This will cause sync to get stuck at the missing heights.
         assert!(
-            saw_process_response,
-            "BUG: non-contiguous response is currently accepted (forwarded to consensus)"
+            saw_send_request,
+            "Expected a re-request to another peer after non-contiguous response"
         );
         assert!(
-            !saw_send_request,
-            "BUG: no re-request is triggered for non-contiguous response"
+            !saw_process_response,
+            "Non-contiguous response should NOT have been forwarded to consensus"
         );
     }
 }

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -895,8 +895,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arc_malachitebft_test::{Height, TestContext};
+    use arc_malachitebft_test::{Height, TestContext, ValueId};
+    use bytes::Bytes;
+    use malachitebft_core_types::{CommitCertificate, Round};
+    use rand::SeedableRng;
     use std::collections::BTreeMap;
+
+    use crate::effect::Resumable;
+    use crate::Config;
 
     type TestPendingRequests = BTreeMap<OutboundRequestId, (RangeInclusive<Height>, PeerId)>;
 
@@ -1247,5 +1253,123 @@ mod tests {
         let range = tip_height..=Height::new(25);
         let clamped = clamp(&range, tip_height);
         assert_eq!(clamped, tip_height..=tip_height);
+    }
+
+    fn make_raw_decided_value(height: u64) -> RawDecidedValue<TestContext> {
+        RawDecidedValue {
+            value_bytes: Bytes::new(),
+            certificate: CommitCertificate {
+                height: Height::new(height),
+                round: Round::new(0),
+                value_id: ValueId::new(height),
+                commit_signatures: vec![],
+            },
+        }
+    }
+
+    /// Test that a non-contiguous sync response (e.g., request 1..=10, get 1,2,5..12)
+    /// is rejected by the sync state machine and triggers a re-request from another peer.
+    ///
+    /// BUG: Without contiguity validation, the response is incorrectly accepted
+    /// and forwarded to consensus. Consensus will get stuck when it advances to
+    /// the missing heights (3, 4) and finds nothing in the queue.
+    #[test]
+    fn test_non_contiguous_response_rejected_by_sync_handler() {
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        let request_id = OutboundRequestId::new("req-1");
+
+        let mut state = State::<TestContext>::new(
+            Box::new(rand::rngs::StdRng::seed_from_u64(42)),
+            Config::default(),
+        );
+
+        // Set up state: consensus is at height 1, we have a pending request for 1..=10 from peer_a
+        state.consensus_height = Height::new(1);
+        state.tip_height = Height::new(0);
+        state.sync_height = Height::new(11);
+        state.started = true;
+        state.pending_requests.insert(
+            request_id.clone(),
+            (Height::new(1)..=Height::new(10), peer_a),
+        );
+
+        // Add peer_b so re-request can find another peer
+        state.update_status(Status {
+            peer_id: peer_b,
+            tip_height: Height::new(20),
+            history_min_height: Height::new(1),
+        });
+
+        // Build a malformed response: 10 values starting at height 1
+        // but with a gap (heights 1, 2, 5, 6, 7, 8, 9, 10, 11, 12)
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(1),
+                make_raw_decided_value(2),
+                make_raw_decided_value(5),
+                make_raw_decided_value(6),
+                make_raw_decided_value(7),
+                make_raw_decided_value(8),
+                make_raw_decided_value(9),
+                make_raw_decided_value(10),
+                make_raw_decided_value(11),
+                make_raw_decided_value(12),
+            ],
+        );
+
+        let input = Input::ValueResponse(request_id, peer_a, Some(response));
+        let metrics = Metrics::default();
+
+        // Drive the sync handler through the coroutine
+        let mut gen = crate::co::Gen::new(|co| handle(co, &mut state, &metrics, input));
+        let mut result = gen.resume_with(Resume::default());
+
+        // The handler should reject the response and re-request from another peer.
+        // This means it should yield a SendValueRequest effect (to peer_b).
+        // If it instead yields ProcessValueResponse, the response was incorrectly accepted.
+        let mut saw_send_request = false;
+        let mut saw_process_response = false;
+
+        loop {
+            match result {
+                genawaiter::GeneratorState::Yielded(effect) => {
+                    match &effect {
+                        Effect::SendValueRequest(peer, _, _) => {
+                            saw_send_request = true;
+                            // Should re-request from peer_b (not peer_a)
+                            assert_eq!(*peer, peer_b);
+                        }
+                        Effect::ProcessValueResponse(_, _, _, _) => {
+                            saw_process_response = true;
+                        }
+                        _ => {}
+                    }
+
+                    // Resume with appropriate value based on effect type
+                    let resume = match effect {
+                        Effect::SendValueRequest(_, _, r) => {
+                            r.resume_with(Some(OutboundRequestId::new("req-2")))
+                        }
+                        _ => Resume::default(),
+                    };
+                    result = gen.resume_with(resume);
+                }
+                genawaiter::GeneratorState::Complete(_) => break,
+            }
+        }
+
+        // BUG: Currently the response is accepted (ProcessValueResponse emitted)
+        // instead of being rejected (SendValueRequest emitted).
+        // This will cause sync to get stuck at the missing heights.
+        assert!(
+            saw_process_response,
+            "BUG: non-contiguous response is currently accepted (forwarded to consensus)"
+        );
+        assert!(
+            !saw_send_request,
+            "BUG: no re-request is triggered for non-contiguous response"
+        );
     }
 }

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -1360,6 +1360,8 @@ mod tests {
     /// is rejected by the sync state machine and triggers a re-request from another peer.
     #[test]
     fn test_non_contiguous_response_rejected_by_sync_handler() {
+        use std::cell::Cell;
+
         let peer_a = PeerId::random();
         let peer_b = PeerId::random();
         let request_id = OutboundRequestId::new("req-1");
@@ -1369,7 +1371,7 @@ mod tests {
             Config::default(),
         );
 
-        // Set up state: consensus is at height 1, we have a pending request for 1..=10 from peer_a
+        // Set up state: consensus is at height 1, pending request for 1..=10 from peer_a
         state.consensus_height = Height::new(1);
         state.tip_height = Height::new(0);
         state.sync_height = Height::new(11);
@@ -1407,50 +1409,48 @@ mod tests {
         let input = Input::ValueResponse(request_id, peer_a, Some(response));
         let metrics = Metrics::default();
 
-        // Drive the sync handler through the coroutine
-        let mut gen = crate::co::Gen::new(|co| handle(co, &mut state, &metrics, input));
-        let mut result = gen.resume_with(Resume::default());
-
         // The handler should reject the response and re-request from another peer.
-        // This means it should yield a SendValueRequest effect (to peer_b).
-        // If it instead yields ProcessValueResponse, the response was incorrectly accepted.
-        let mut saw_send_request = false;
-        let mut saw_process_response = false;
+        // It should yield SendValueRequest (to peer_b), NOT ProcessValueResponse.
+        let saw_send_request = Cell::new(false);
+        let saw_process_response = Cell::new(false);
 
-        loop {
-            match result {
-                genawaiter::GeneratorState::Yielded(effect) => {
+        let result: Result<(), Error<TestContext>> = (|| {
+            crate::process!(
+                input: input,
+                state: &mut state,
+                metrics: &metrics,
+                with: effect => {
                     match &effect {
                         Effect::SendValueRequest(peer, _, _) => {
-                            saw_send_request = true;
-                            // Should re-request from peer_b (not peer_a)
+                            saw_send_request.set(true);
                             assert_eq!(*peer, peer_b);
                         }
                         Effect::ProcessValueResponse(_, _, _, _) => {
-                            saw_process_response = true;
+                            saw_process_response.set(true);
                         }
                         _ => {}
                     }
 
-                    // Resume with appropriate value based on effect type
-                    let resume = match effect {
+                    Ok::<_, eyre::Report>(match effect {
                         Effect::SendValueRequest(_, _, r) => {
                             r.resume_with(Some(OutboundRequestId::new("req-2")))
                         }
-                        _ => Resume::default(),
-                    };
-                    result = gen.resume_with(resume);
+                        Effect::BroadcastStatus(_, r) => r.resume_with(()),
+                        Effect::SendValueResponse(_, _, r) => r.resume_with(()),
+                        Effect::GetDecidedValues(_, _, r) => r.resume_with(()),
+                        Effect::ProcessValueResponse(_, _, _, r) => r.resume_with(()),
+                    })
                 }
-                genawaiter::GeneratorState::Complete(_) => break,
-            }
-        }
+            )
+        })();
 
+        assert!(result.is_ok(), "Handler returned error: {result:?}");
         assert!(
-            saw_send_request,
+            saw_send_request.get(),
             "Expected a re-request to another peer after non-contiguous response"
         );
         assert!(
-            !saw_process_response,
+            !saw_process_response.get(),
             "Non-contiguous response should NOT have been forwarded to consensus"
         );
     }


### PR DESCRIPTION
Closes: #1541

## Summary

When a sync response contains values with non-contiguous certificate heights (e.g., request 1..=10, response has certificates for heights 1,2,5..12), the existing validation passes because `end_height` is computed from `start_height + values.len() - 1` without inspecting actual certificate heights. Values get buffered by their real certificate height, causing sync to get stuck when consensus advances to a missing height and finds nothing in the queue.

This PR adds a contiguity check in `on_value_response()` that verifies each value's `certificate.height == start_height + index` before processing. Non-contiguous responses are rejected and re-requested from a different peer.

The check only reads `certificate.height` (a direct struct field access) — no value decoding is needed.

## Tests

- **`test_validate_value_response_heights`**: Unit test on the extracted `validate_value_response_heights()` function. Covers valid contiguous responses, empty responses, gaps in heights, duplicate heights, wrong start height, and reversed order.
- **`test_non_contiguous_response_rejected_by_sync_handler`**: Handler-level test that drives the sync state machine coroutine with a crafted non-contiguous response (request 1..=10, get heights 1,2,5..12). Verifies the response triggers a `SendValueRequest` effect (re-request to another peer) and no `ProcessValueResponse` effect (response not forwarded to consensus).

---

### PR author checklist

#### Contribution eligibility

- [x] I am a core contributor, OR I have been explicitly assigned to the linked issue
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and my PR complies with all requirements
- [x] I understand that PRs not meeting these requirements will be closed without review

#### For all contributors

- [x] Reference a GitHub issue
- [x] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [x] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [x] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests