### PR TITLE
fix(starknet-p2p-types): return error for invalid address public key bytes

### DIFF
--- a/code/crates/signing-ed25519/src/lib.rs
+++ b/code/crates/signing-ed25519/src/lib.rs
@@ -195,6 +195,10 @@ impl PublicKey {
         Self(ed25519_consensus::VerificationKey::try_from(bytes).unwrap())
     }
 
+    pub fn try_from_bytes(bytes: [u8; 32]) -> Result<Self, ed25519_consensus::Error> {
+        ed25519_consensus::VerificationKey::try_from(bytes).map(Self)
+    }
+
     pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), signature::Error> {
         self.0
             .verify(signature.inner(), msg)

--- a/code/crates/starknet/p2p-types/src/address.rs
+++ b/code/crates/starknet/p2p-types/src/address.rs
@@ -55,12 +55,58 @@ impl Protobuf for Address {
 
         let mut bytes = [0; 32];
         bytes.copy_from_slice(&proto.elements);
-        Ok(Address::new(bytes))
+
+        let public_key = PublicKey::try_from_bytes(bytes).map_err(|e| {
+            ProtoError::Other(format!("Invalid public key bytes: {e}"))
+        })?;
+
+        Ok(Address::from_public_key(public_key))
     }
 
     fn to_proto(&self) -> Result<Self::Proto, ProtoError> {
         Ok(p2p_proto::Address {
             elements: Bytes::copy_from_slice(self.0.as_bytes().as_slice()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_proto_rejects_invalid_public_key_bytes() {
+        // Scan for a 32-byte value that ed25519-consensus rejects.
+        // Roughly half of all y-coordinates fail point decompression.
+        let mut bytes = [0u8; 32];
+        for candidate in 0u8..=255 {
+            bytes[0] = candidate;
+            if PublicKey::try_from_bytes(bytes).is_err() {
+                let proto = p2p_proto::Address {
+                    elements: Bytes::copy_from_slice(&bytes),
+                };
+
+                let result = Address::from_proto(proto);
+                assert!(result.is_err(), "expected error for invalid public key bytes");
+
+                let err_msg = result.unwrap_err().to_string();
+                assert!(
+                    err_msg.contains("Invalid public key bytes"),
+                    "unexpected error message: {err_msg}"
+                );
+                return;
+            }
+        }
+        panic!("could not find invalid Ed25519 public key bytes for test");
+    }
+
+    #[test]
+    fn from_proto_rejects_wrong_length() {
+        let proto = p2p_proto::Address {
+            elements: Bytes::from_static(&[0; 16]),
+        };
+
+        let result = Address::from_proto(proto);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

`Address::from_proto()` in `starknet-p2p-types` can panic on malformed 32-byte public key data instead of returning `ProtoError`.

## Problem

`Address::from_proto()` checks that the input is 32 bytes, then calls `Address::new(bytes)` which reaches `PublicKey::from_bytes(bytes)`. That constructor calls `VerificationKey::try_from(bytes).unwrap()`, so invalid Ed25519 public key bytes with the correct length cause a panic during protobuf decoding.

## Fix

- Add `PublicKey::try_from_bytes(bytes) -> Result<Self, Error>` fallible constructor to `signing-ed25519`
- Use it in `Address::from_proto()` to return `ProtoError` on invalid key bytes instead of panicking
- Add regression tests covering both invalid 32-byte input and wrong-length input

## Changes

**`code/crates/signing-ed25519/src/lib.rs`**
- Add `PublicKey::try_from_bytes()` that returns `Result` instead of panicking

**`code/crates/starknet/p2p-types/src/address.rs`**
- Update `from_proto()` to use `PublicKey::try_from_bytes()` and map the error to `ProtoError`
- Add test `from_proto_rejects_invalid_public_key_bytes`
- Add test `from_proto_rejects_wrong_length`

## Verification

- `cargo check -p arc-malachitebft-starknet-p2p-types` passes
- `cargo test -p arc-malachitebft-starknet-p2p-types` passes (2 tests)
- `cargo clippy -p arc-malachitebft-starknet-p2p-types -p arc-malachitebft-signing-ed25519 -- -D warnings` passes

Closes #1544