### PR TITLE
chore: migrate all workflows from github-hosted runners to ubuntu-latest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   changes:
     name: Detect changes
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
@@ -40,7 +40,7 @@ jobs:
     name: Integration
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.codecov == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-large
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: code
@@ -90,7 +90,7 @@ jobs:
   #   name: MBT
   #   needs: changes
   #   if: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.specs == 'true' || needs.changes.outputs.codecov == 'true' || github.ref == 'refs/heads/main' }}
-  #   runs-on: github-hosted-large
+  #   runs-on: ubuntu-latest
   #   defaults:
   #     run:
   #       working-directory: code
@@ -144,7 +144,7 @@ jobs:
     name: Upload coverage to Codecov
     # needs: [changes, integration, mbt]
     # needs: [changes, integration]
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     if: ${{ !cancelled() && (needs.changes.outputs.code == 'true' || needs.changes.outputs.specs == 'true' || needs.changes.outputs.codecov == 'true' || github.ref == 'refs/heads/main') }}
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   changes:
     name: Detect changes
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
@@ -33,7 +33,7 @@ jobs:
     name: Build
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: code
@@ -62,7 +62,7 @@ jobs:
 
   deploy:
     name: Deploy
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     needs: build
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   linkChecker:
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/mbt.yml
+++ b/.github/workflows/mbt.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   changes:
     name: Detect changes
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
@@ -29,7 +29,7 @@ jobs:
     name: MBT Tests
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.specs == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-large
+    runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_DEV_DEBUG: 1

--- a/.github/workflows/need-triage-label.yml
+++ b/.github/workflows/need-triage-label.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-eligibility:
     name: Check eligibility
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     steps:
       - name: Check if author is allowed bot
         id: check-dependabot

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: Check PR title
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     steps:
@@ -21,7 +21,7 @@ jobs:
 
   verify-signatures:
     name: Verify commit signatures
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     name: Publish to crates.io
-    runs-on: github-hosted-large
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/quint.yml
+++ b/.github/workflows/quint.yml
@@ -10,7 +10,7 @@ name: Quint
 jobs:
   changes:
     name: Detect changes
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
@@ -28,7 +28,7 @@ jobs:
     name: Typecheck
     needs: changes
     if: ${{ needs.changes.outputs.specs == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -41,7 +41,7 @@ jobs:
     name: Test
     needs: changes
     if: ${{ needs.changes.outputs.specs == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-large
+    runs-on: ubuntu-latest
     env:
       MAX_SAMPLES: 100
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   changes:
     name: Detect changes
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
@@ -34,7 +34,7 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: code
@@ -68,7 +68,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: github-hosted-large
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: code
@@ -113,7 +113,7 @@ jobs:
     name: no_std compatibility
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: code
@@ -130,7 +130,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -147,7 +147,7 @@ jobs:
 
   fmt:
     name: Formatting
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -165,7 +165,7 @@ jobs:
     name: MSRV
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: code
@@ -186,7 +186,7 @@ jobs:
     name: Standalone
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: code

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   changes:
     name: Detect changes
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
@@ -33,7 +33,7 @@ jobs:
     name: Detect semver violations
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write # Necessary to post comments on PRs
       contents: read

--- a/.github/workflows/todo-tracking.yml
+++ b/.github/workflows/todo-tracking.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   update-todos:
     name: Update TODOs and FIXMEs
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   codespell:
     name: Check spelling
-    runs-on: github-hosted-small
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: crate-ci/typos@30eea72e385d435c00a24eeba0d96f87048f42ec # master


### PR DESCRIPTION
Replace github-hosted-small and github-hosted-large with ubuntu-latest across all 13 workflow files. Our custom hosted runners are having issues queueing at the moment.

---

### PR author checklist

#### Contribution eligibility

- [x] I am a core contributor, OR I have been explicitly assigned to the linked issue
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and my PR complies with all requirements
- [x] I understand that PRs not meeting these requirements will be closed without review

#### For all contributors

- [ ] Reference a GitHub issue
- [ ] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

#### For external contributors

- [ ] Maintainers of Malachite are [allowed to push changes to the branch][gh-edit-branch]

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[gh-edit-branch]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests
