### PR TITLE
chore: Port downstream fork commits upstream

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@
 - Allow dynamic adjustment of timeout parameters ([#1227](https://github.com/circlefin/malachite/pull/1227))
 - Allow providing both the validator set and the timeouts for a height in `StartHeight`, `RestartHeight` and `ConsensusReady` reply ([#1227](https://github.com/circlefin/malachite/pull/1227))
 - Remove `initial_validator_set` and `initial_height` fields from `Params` struct ([#1190](https://github.com/circlefin/malachite/pull/1190))
+- Drop synced values whose id does not match the accompanying commit certificate before forwarding to consensus
 
 ### `discovery`
 - Can connect request calls the wrong controller action

--- a/code/crates/core-consensus/src/handle/sync.rs
+++ b/code/crates/core-consensus/src/handle/sync.rs
@@ -104,15 +104,35 @@ where
 
     let peer = value.peer;
 
-    let effect = process_commit_certificate(co, state, metrics, value.certificate.clone())
-        .await
-        .map(|_| Effect::ValidSyncValue(value, proposer, Default::default()))
-        .unwrap_or_else(|e| {
+    match process_commit_certificate(co, state, metrics, value.certificate.clone()).await {
+        Ok(()) => {
+            // If consensus has decided after certificate processing, then a matching
+            // `ProposedValue` must be stored locally (from WAL replay or from a race
+            // with consensus path). This can only happen if the host had previously
+            // accepted and stored a valid value matching the certificate.
+            // Forwarding the value bytes to the host would be redundant work and the
+            // new `ProposedValue` from the host response would be dropped later.
+            // We skip penalizing the peer if the value_id didn't match the certificate.
+            if state.driver.step_is_commit() {
+                debug!(
+                    certificate.height = %cert_height,
+                    "Decided using existing proposed value and certificate from sync; skip forwarding of value bytes to the application"
+                );
+            } else {
+                perform!(
+                    co,
+                    Effect::ValidSyncValue(value, proposer, Default::default())
+                );
+            }
+        }
+        Err(e) => {
             error!("Error when processing commit certificate: {e}");
-            Effect::InvalidSyncValue(peer, cert_height, e, Default::default())
-        });
-
-    perform!(co, effect);
+            perform!(
+                co,
+                Effect::InvalidSyncValue(peer, cert_height, e, Default::default())
+            );
+        }
+    }
 
     Ok(())
 }

--- a/code/crates/core-consensus/tests/sync_cert_verification.rs
+++ b/code/crates/core-consensus/tests/sync_cert_verification.rs
@@ -74,6 +74,50 @@ fn build_commit_certificate(
     }
 }
 
+/// Handle the effects emitted by the consensus core during these tests:
+/// signature verification, signing, and commit-certificate verification.
+///
+/// All signing/verification is performed using `signers[0]`. If `verify_cert_count` is
+/// `Some`, it is incremented every time a `VerifyCommitCertificate` effect is observed.
+///
+/// Effects not handled here are forwarded to `fallback` so the caller can apply
+/// test-specific logic.
+fn handle_effect_with_default<F>(
+    signers: &[Ed25519Signer],
+    verify_cert_count: Option<&Cell<u32>>,
+    effect: Effect<TestContext>,
+    fallback: F,
+) -> Resume<TestContext>
+where
+    F: FnOnce(Effect<TestContext>) -> Resume<TestContext>,
+{
+    use Effect::*;
+    match effect {
+        VerifySignature(_, _, r) => r.resume_with(true),
+        SignVote(vote, r) => {
+            let signed = block_on(signers[0].sign_vote(vote)).unwrap();
+            r.resume_with(signed)
+        }
+        SignProposal(proposal, r) => {
+            let signed = block_on(signers[0].sign_proposal(proposal)).unwrap();
+            r.resume_with(signed)
+        }
+        VerifyCommitCertificate(cert, validator_set, tp, r) => {
+            if let Some(counter) = verify_cert_count {
+                counter.set(counter.get() + 1);
+            }
+            let result = block_on(signers[0].verify_commit_certificate(
+                &TestContext::new(),
+                &cert,
+                &validator_set,
+                tp,
+            ));
+            r.resume_with(result)
+        }
+        other => fallback(other),
+    }
+}
+
 /// Test that the sync decision path verifies the commit certificate only once,
 /// in sync.rs at the trust boundary. The certificate stored in the driver is
 /// already verified and does not need re-verification in decide.rs.
@@ -100,29 +144,12 @@ fn sync_decision_path_verifies_commit_certificate_once() {
     let verify_count = Cell::new(0u32);
 
     let handle_effect = |effect: Effect<TestContext>| -> Result<Resume<TestContext>, ()> {
-        use Effect::*;
-        Ok(match effect {
-            VerifySignature(_, _, r) => r.resume_with(true),
-            SignVote(vote, r) => {
-                let signed = block_on(signers[0].sign_vote(vote)).unwrap();
-                r.resume_with(signed)
-            }
-            SignProposal(proposal, r) => {
-                let signed = block_on(signers[0].sign_proposal(proposal)).unwrap();
-                r.resume_with(signed)
-            }
-            VerifyCommitCertificate(cert, validator_set, tp, r) => {
-                verify_count.set(verify_count.get() + 1);
-                let result = block_on(signers[0].verify_commit_certificate(
-                    &TestContext::new(),
-                    &cert,
-                    &validator_set,
-                    tp,
-                ));
-                r.resume_with(result)
-            }
-            _ => Resume::Continue,
-        })
+        Ok(handle_effect_with_default(
+            &signers,
+            Some(&verify_count),
+            effect,
+            |_| Resume::Continue,
+        ))
     };
 
     // Step 1: Start height
@@ -177,5 +204,171 @@ fn sync_decision_path_verifies_commit_certificate_once() {
         verify_count.get(),
         1,
         "Certificate should be verified only once on sync decision path"
+    );
+}
+
+/// When a sync `ValueResponse` is processed and the matching `ProposedValue` is already
+/// known locally (e.g., from WAL replay or via the consensus race), `process_commit_certificate`
+/// drives the state machine to a decision. In that case there is no point in forwarding the
+/// raw value bytes to the host via `Effect::ValidSyncValue` as the host has already accepted
+/// the value through the local proposed-value path. This test asserts that `ValidSyncValue`
+/// is not emitted in that case.
+#[test]
+fn sync_value_response_skips_valid_sync_value_when_already_decided() {
+    let entries: Vec<(Validator, _)> = make_validators([25, 25, 25, 25]).into();
+    let validators: Vec<Validator> = entries.iter().map(|(v, _)| v.clone()).collect();
+    let signers: Vec<Ed25519Signer> = entries
+        .into_iter()
+        .map(|(_, pk)| Ed25519Signer::new(pk))
+        .collect();
+
+    let my_addr = validators[0].address;
+    let mut state = make_state(&validators, my_addr);
+    let metrics = Metrics::new();
+    let vs = ValidatorSet::new(validators.clone());
+
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value = Value::new(42);
+
+    let valid_sync_value_count = Cell::new(0u32);
+    let invalid_sync_value_count = Cell::new(0u32);
+
+    let handle_effect = |effect: Effect<TestContext>| -> Result<Resume<TestContext>, ()> {
+        Ok(handle_effect_with_default(
+            &signers,
+            None,
+            effect,
+            |effect| {
+                use Effect::*;
+                match effect {
+                    ValidSyncValue(_, _, r) => {
+                        valid_sync_value_count.set(valid_sync_value_count.get() + 1);
+                        r.resume_with(())
+                    }
+                    InvalidSyncValue(_, _, _, r) => {
+                        invalid_sync_value_count.set(invalid_sync_value_count.get() + 1);
+                        r.resume_with(())
+                    }
+                    _ => Resume::Continue,
+                }
+            },
+        ))
+    };
+
+    run(process!(
+        input: Input::StartHeight(height, vs, false, None),
+        state: &mut state,
+        metrics: &metrics,
+        with: effect => handle_effect(effect)
+    ));
+
+    // Step 1: Provide the proposed value first (simulates WAL-replayed/locally-stored value)
+    run(process!(
+        input: Input::ProposedValue(
+            ProposedValue {
+                height,
+                round,
+                valid_round: Round::Nil,
+                proposer: my_addr,
+                value: value.clone(),
+                validity: Validity::Valid,
+            },
+            ValueOrigin::Consensus,
+        ),
+        state: &mut state,
+        metrics: &metrics,
+        with: effect => handle_effect(effect)
+    ));
+
+    // Step 2: The sync value response arrives with the matching certificate.
+    // Since the value is already stored, `process_commit_certificate` should drive
+    // the state machine straight to a decision, and `ValidSyncValue` must be skipped.
+    let certificate = build_commit_certificate(&validators, &signers, height, round, &value);
+    let value_response =
+        ValueResponse::new(PeerId::random(), Bytes::from("value-bytes"), certificate);
+
+    run(process!(
+        input: Input::SyncValueResponse(value_response),
+        state: &mut state,
+        metrics: &metrics,
+        with: effect => handle_effect(effect)
+    ));
+
+    assert_eq!(
+        valid_sync_value_count.get(),
+        0,
+        "ValidSyncValue must not be emitted when the certificate processing already decided"
+    );
+    assert_eq!(
+        invalid_sync_value_count.get(),
+        0,
+        "InvalidSyncValue must not be emitted on a successful sync decision"
+    );
+}
+
+/// Sanity-check the inverse: when no matching `ProposedValue` is stored locally,
+/// `process_commit_certificate` cannot reach a decision on its own and `ValidSyncValue`
+/// must still be emitted so the host can decode the value bytes.
+#[test]
+fn sync_value_response_emits_valid_sync_value_when_not_decided() {
+    let entries: Vec<(Validator, _)> = make_validators([25, 25, 25, 25]).into();
+    let validators: Vec<Validator> = entries.iter().map(|(v, _)| v.clone()).collect();
+    let signers: Vec<Ed25519Signer> = entries
+        .into_iter()
+        .map(|(_, pk)| Ed25519Signer::new(pk))
+        .collect();
+
+    let my_addr = validators[0].address;
+    let mut state = make_state(&validators, my_addr);
+    let metrics = Metrics::new();
+    let vs = ValidatorSet::new(validators.clone());
+
+    let height = Height::new(1);
+    let round = Round::new(0);
+    let value = Value::new(42);
+
+    let valid_sync_value_count = Cell::new(0u32);
+
+    let handle_effect = |effect: Effect<TestContext>| -> Result<Resume<TestContext>, ()> {
+        Ok(handle_effect_with_default(
+            &signers,
+            None,
+            effect,
+            |effect| {
+                use Effect::*;
+                match effect {
+                    ValidSyncValue(_, _, r) => {
+                        valid_sync_value_count.set(valid_sync_value_count.get() + 1);
+                        r.resume_with(())
+                    }
+                    _ => Resume::Continue,
+                }
+            },
+        ))
+    };
+
+    run(process!(
+        input: Input::StartHeight(height, vs, false, None),
+        state: &mut state,
+        metrics: &metrics,
+        with: effect => handle_effect(effect)
+    ));
+
+    let certificate = build_commit_certificate(&validators, &signers, height, round, &value);
+    let value_response =
+        ValueResponse::new(PeerId::random(), Bytes::from("value-bytes"), certificate);
+
+    run(process!(
+        input: Input::SyncValueResponse(value_response),
+        state: &mut state,
+        metrics: &metrics,
+        with: effect => handle_effect(effect)
+    ));
+
+    assert_eq!(
+        valid_sync_value_count.get(),
+        1,
+        "ValidSyncValue must be emitted when no decision was reached during certificate processing"
     );
 }

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -22,7 +22,7 @@ use malachitebft_core_consensus::{
 };
 use malachitebft_core_types::{
     CommitCertificate, Context, Proposal, Round, Timeout, TimeoutKind, Timeouts, ValidatorProof,
-    ValidatorSet, Validity, Value, ValueId, ValueOrigin, ValueResponse as CoreValueResponse, Vote,
+    ValidatorSet, Value, ValueId, ValueOrigin, ValueResponse as CoreValueResponse, Vote,
 };
 use malachitebft_metrics::Metrics;
 use malachitebft_signing::{Signer, Verifier, VerifierExt};
@@ -1604,16 +1604,25 @@ where
                         reply_to,
                     },
                     move |proposed| {
-                        if proposed.validity == Validity::Invalid
-                            || proposed.value.id() != value.certificate.value_id
-                        {
+                        if proposed.value.id() == value.certificate.value_id {
+                            // Id matches the certificate — forward to consensus.
+                            // A locally-invalid validity is still forwarded so the
+                            // downstream `maybe_sync_decision` path can surface the
+                            // version-skew diagnostic to operators.
+                            let _ = myself.cast(Msg::<Ctx>::ReceivedProposedValue(
+                                proposed,
+                                ValueOrigin::Sync,
+                            ));
+                        } else {
+                            warn!(
+                                peer = %value.peer,
+                                height = %certificate_height,
+                                proposed.value_id = %proposed.value.id(),
+                                certificate.value_id = %value.certificate.value_id,
+                                "Synced value id does not match commit certificate, rejecting"
+                            );
                             sync.send(SyncMsg::InvalidValue(value.peer, certificate_height));
                         }
-
-                        let _ = myself.cast(Msg::<Ctx>::ReceivedProposedValue(
-                            proposed,
-                            ValueOrigin::Sync,
-                        ));
                     },
                     move || {
                         sync_on_none.send(SyncMsg::ValueProcessingError(

--- a/code/crates/network/src/lib.rs
+++ b/code/crates/network/src/lib.rs
@@ -1137,32 +1137,34 @@ async fn handle_sync_event(
                 } => {
                     state.sync_channels.insert(request_id, channel);
 
-                    let _ = tx_event
+                    if let Err(e) = tx_event
                         .send(Event::Sync(sync::RawMessage::Request {
                             request_id,
                             peer: PeerId::from_libp2p(&peer),
                             body: request.0,
                         }))
                         .await
-                        .map_err(|e| {
-                            error!("Error sending Sync request to handle: {e}");
-                        });
+                    {
+                        error!("Error sending Sync request to handle: {e}");
+                        return ControlFlow::Break(());
+                    }
                 }
 
                 libp2p::request_response::Message::Response {
                     request_id,
                     response,
                 } => {
-                    let _ = tx_event
+                    if let Err(e) = tx_event
                         .send(Event::Sync(sync::RawMessage::Response {
                             request_id,
                             peer: PeerId::from_libp2p(&peer),
                             body: response.0,
                         }))
                         .await
-                        .map_err(|e| {
-                            error!("Error sending Sync response to handle: {e}");
-                        });
+                    {
+                        error!("Error sending Sync response to handle: {e}");
+                        return ControlFlow::Break(());
+                    }
                 }
             }
 
@@ -1193,15 +1195,16 @@ async fn handle_validator_proof_event(
     match event {
         validator_proof::Event::ProofReceived { peer, proof_bytes } => {
             // Forward to engine for verification
-            let _ = tx_event
+            if let Err(e) = tx_event
                 .send(Event::ValidatorProofReceived {
                     peer_id: PeerId::from_libp2p(&peer),
                     proof_bytes,
                 })
                 .await
-                .map_err(|e| {
-                    error!("Error sending ValidatorProofReceived to handle: {e}");
-                });
+            {
+                error!("Error sending ValidatorProofReceived to handle: {e}");
+                return ControlFlow::Break(());
+            }
 
             ControlFlow::Continue(())
         }
@@ -1236,5 +1239,50 @@ impl PeerIdExt for PeerId {
 
     fn from_libp2p(peer_id: &libp2p::PeerId) -> Self {
         Self::from_bytes(&peer_id.to_bytes()).expect("valid PeerId")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn handle_validator_proof_event_breaks_when_event_receiver_dropped() {
+        let (tx_event, rx_event) = mpsc::channel::<Event>(1);
+        drop(rx_event);
+
+        let event = validator_proof::Event::ProofReceived {
+            peer: libp2p::PeerId::random(),
+            proof_bytes: Bytes::new(),
+        };
+
+        let result = handle_validator_proof_event(event, &tx_event).await;
+        assert!(matches!(result, ControlFlow::Break(())));
+    }
+
+    #[tokio::test]
+    async fn handle_validator_proof_event_forwards_proof_and_continues() {
+        let (tx_event, mut rx_event) = mpsc::channel::<Event>(1);
+
+        let peer = libp2p::PeerId::random();
+        let event = validator_proof::Event::ProofReceived {
+            peer,
+            proof_bytes: Bytes::from_static(b"proof"),
+        };
+
+        let result = handle_validator_proof_event(event, &tx_event).await;
+        assert!(matches!(result, ControlFlow::Continue(())));
+
+        let forwarded = rx_event.recv().await.expect("event forwarded to engine");
+        match forwarded {
+            Event::ValidatorProofReceived {
+                peer_id,
+                proof_bytes,
+            } => {
+                assert_eq!(peer_id, PeerId::from_libp2p(&peer));
+                assert_eq!(proof_bytes.as_ref(), b"proof");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 }

--- a/code/crates/network/src/metrics.rs
+++ b/code/crates/network/src/metrics.rs
@@ -25,7 +25,6 @@ pub(crate) struct PeerInfoLabels {
     slot: String,
     peer_moniker: String,
     peer_id: String,
-    address: String,
     peer_type: PeerType,
     consensus_address: String, // Consensus address for validators, "none" for non-validators
 }
@@ -52,7 +51,6 @@ impl PeerInfo {
             slot: slot.to_string(),
             peer_moniker: self.moniker.clone(),
             peer_id: peer_id.to_string(),
-            address: self.address.to_string(),
             peer_type: self.peer_type,
             // Show verified consensus_address if known, "none" if never verified
             consensus_address: self
@@ -66,7 +64,6 @@ impl PeerInfo {
     /// Used to determine if metrics need to be updated (stale marking).
     pub(crate) fn labels_match(&self, other: &PeerInfo) -> bool {
         self.moniker == other.moniker
-            && self.address == other.address
             && self.peer_type == other.peer_type
             && self.consensus_address == other.consensus_address
     }
@@ -88,9 +85,12 @@ pub(crate) struct Metrics {
     local_node_info: Family<LocalNodeLabels, Gauge>,
     /// Discovered peers with basic info (gauge value = peer score)
     discovered_peers: Family<PeerInfoLabels, Gauge>,
-    /// Per-peer, per-topic mesh membership (1 = in mesh, 0 = not in mesh)
+    /// Per-peer, per-topic mesh membership.
+    /// Entry present with value 1 = in mesh; entry absent = not in mesh.
     peer_mesh_membership: Family<MeshMembershipLabels, Gauge>,
-    /// Explicit peers in gossipsub (1 = active, i64::MIN = disconnected/stale)
+    /// Explicit peers in gossipsub.
+    /// Entry present with value 1 = currently configured as an explicit peer;
+    /// entry absent = not explicit / disconnected.
     explicit_peers: Family<ExplicitPeerLabels, Gauge>,
     /// PeerId to slot number mapping
     peer_slots: Slots<PeerId>,
@@ -126,13 +126,13 @@ impl Metrics {
 
         registry.register(
             "peer_mesh_membership",
-            "Per-peer, per-topic gossipsub mesh membership (1 = in mesh, 0 = not in mesh)",
+            "Per-peer, per-topic gossipsub mesh membership (entry present with value 1 = in mesh; entry absent = not in mesh)",
             mesh_membership.clone(),
         );
 
         registry.register(
             "explicit_peers",
-            "Peers added as explicit peers in gossipsub (1 = active, i64::MIN = disconnected)",
+            "Peers added as explicit peers in gossipsub (entry present with value 1 = active; entry absent = not explicit / disconnected)",
             explicit_peers.clone(),
         );
 
@@ -182,17 +182,17 @@ impl Metrics {
             // Update mesh membership metrics for topics that changed
             let old_topics = &peer_info.topics;
 
-            // Topics that were removed: set to 0
+            // Topics that were removed
             for topic in old_topics.difference(new_topics) {
                 let mesh_labels = MeshMembershipLabels {
                     peer_id: peer_id.to_string(),
                     peer_moniker: peer_info.moniker.clone(),
                     topic: topic.clone(),
                 };
-                self.peer_mesh_membership.get_or_create(&mesh_labels).set(0);
+                self.peer_mesh_membership.remove(&mesh_labels);
             }
 
-            // Topics that were added: set to 1
+            // Topics that were added
             for topic in new_topics.difference(old_topics) {
                 let mesh_labels = MeshMembershipLabels {
                     peer_id: peer_id.to_string(),
@@ -217,19 +217,18 @@ impl Metrics {
     pub(crate) fn free_slot(&mut self, peer_id: &PeerId, peer_info: &PeerInfo) {
         // Return slot to available pool
         if let Some(slot) = self.peer_slots.release(peer_id) {
-            // Set discovered_peers to i64::MIN to signal disconnection
-            // This allows distinguishing stale entries from active peers in metrics
+            // Remove the peer's entry from the discovered_peers family entirely.
             let labels = peer_info.to_labels(peer_id, slot);
-            self.discovered_peers.get_or_create(&labels).set(i64::MIN);
+            self.discovered_peers.remove(&labels);
 
-            // Clear mesh membership metrics - peer is no longer in any mesh
+            // Clear mesh membership metrics
             for topic in &peer_info.topics {
                 let mesh_labels = MeshMembershipLabels {
                     peer_id: peer_id.to_string(),
                     peer_moniker: peer_info.moniker.clone(),
                     topic: topic.clone(),
                 };
-                self.peer_mesh_membership.get_or_create(&mesh_labels).set(0);
+                self.peer_mesh_membership.remove(&mesh_labels);
             }
 
             debug!("Freed slot {slot} for peer {peer_id}");
@@ -245,13 +244,13 @@ impl Metrics {
         self.explicit_peers.get_or_create(&labels).set(1);
     }
 
-    /// Mark an explicit peer as stale (disconnected)
+    /// Remove an explicit peer entry (peer is disconnected or no longer explicit).
     pub(crate) fn mark_explicit_peer_stale(&self, peer_id: &PeerId, moniker: &str) {
         let labels = ExplicitPeerLabels {
             peer_id: peer_id.to_string(),
             peer_moniker: moniker.to_string(),
         };
-        self.explicit_peers.get_or_create(&labels).set(i64::MIN);
+        self.explicit_peers.remove(&labels);
     }
 
     /// Record metrics for a new peer (assigns slot if needed).
@@ -275,8 +274,9 @@ impl Metrics {
     /// Update metrics for an existing peer when labels may have changed.
     ///
     /// Compares old and new peer info:
-    /// - If labels changed: marks old entry stale, creates new entry
-    /// - If labels unchanged: just updates the score
+    /// - If labels changed: removes the old entry from the metric family and
+    ///   creates a new entry under the updated labels.
+    /// - If labels unchanged: just updates the score.
     ///
     /// Returns true if labels changed.
     pub(crate) fn update_peer_labels(
@@ -292,12 +292,11 @@ impl Metrics {
         let labels_changed = !old_peer_info.labels_match(new_peer_info);
 
         if labels_changed {
-            // Mark old entry as stale
+            // Remove the old entry so it does not leak as a permanent stale
+            // time series.
             let old_labels = old_peer_info.to_labels(peer_id, slot);
-            tracing::debug!(%peer_id, ?old_labels, "Marking peer metric stale");
-            self.discovered_peers
-                .get_or_create(&old_labels)
-                .set(i64::MIN);
+            tracing::debug!(%peer_id, ?old_labels, "Removing stale peer metric entry");
+            self.discovered_peers.remove(&old_labels);
         }
 
         // Create/update metric entry with current labels
@@ -307,5 +306,216 @@ impl Metrics {
             .set(new_peer_info.score as i64);
 
         labels_changed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peer_scoring::FULL_NODE_SCORE;
+    use crate::state::PeerInfo;
+    use libp2p::Multiaddr;
+    use malachitebft_metrics::prometheus::encoding::text::encode;
+    use malachitebft_metrics::Registry;
+    use std::collections::HashSet;
+
+    /// Build a `PeerInfo` for testing. The `address` is included to exercise
+    /// the historical bug path: in the broken implementation, a new address on
+    /// the same peer produced a new time series because the address was part
+    /// of the label set.
+    fn peer_info(moniker: &str, address: &str) -> PeerInfo {
+        PeerInfo {
+            moniker: moniker.to_string(),
+            address: address.parse::<Multiaddr>().unwrap(),
+            consensus_address: None,
+            consensus_public_key: None,
+            peer_type: PeerType::new(false, false),
+            connection_direction: None,
+            score: FULL_NODE_SCORE,
+            topics: HashSet::new(),
+            is_explicit: false,
+        }
+    }
+
+    /// Count time series for a metric name in the encoded Prometheus output.
+    /// Every `<metric_name>{...}` line is a unique series.
+    fn metric_series_count(registry: &Registry, metric_name: &str) -> usize {
+        let mut buf = String::new();
+        encode(&mut buf, registry).unwrap();
+        let prefix = format!("{metric_name}{{");
+        buf.lines().filter(|line| line.starts_with(&prefix)).count()
+    }
+
+    fn discovered_peers_series_count(registry: &Registry) -> usize {
+        metric_series_count(registry, "discovered_peers")
+    }
+
+    /// Repeatedly connect and disconnect the same peer using a fresh ephemeral
+    /// port each time.
+    #[test]
+    fn discovered_peers_bounded_under_ephemeral_port_churn() {
+        let mut registry = Registry::default();
+        let mut metrics = Metrics::new(&mut registry);
+        let peer_id = libp2p::PeerId::random();
+
+        // 500 churns is more than enough to expose unbounded growth — the
+        // production bug saw hundreds of thousands of series per peer.
+        for port in 0..500u16 {
+            let addr = format!("/ip4/10.0.0.1/tcp/{port}");
+            let info = peer_info("peer-a", &addr);
+            metrics.record_new_peer(&peer_id, &info);
+            metrics.free_slot(&peer_id, &info);
+        }
+
+        // After all peers have disconnected, no series should remain.
+        assert_eq!(
+            discovered_peers_series_count(&registry),
+            0,
+            "disconnect must prune the discovered_peers entry"
+        );
+    }
+
+    /// While connected, the same peer must produce at most one series even
+    /// across many reconnections from different ephemeral addresses.
+    #[test]
+    fn discovered_peers_single_series_per_connected_peer() {
+        let mut registry = Registry::default();
+        let mut metrics = Metrics::new(&mut registry);
+        let peer_id = libp2p::PeerId::random();
+
+        for port in 0..100u16 {
+            let addr = format!("/ip4/10.0.0.1/tcp/{port}");
+            let info = peer_info("peer-a", &addr);
+            // Simulate a label-change update with a fresh address on each
+            // iteration; the previous PeerInfo address is irrelevant for
+            // labels and should not leak.
+            let previous = peer_info(
+                "peer-a",
+                &format!("/ip4/10.0.0.1/tcp/{}", port.wrapping_sub(1)),
+            );
+            metrics.record_new_peer(&peer_id, &info);
+            metrics.update_peer_labels(&peer_id, &previous, &info);
+        }
+
+        let count = discovered_peers_series_count(&registry);
+        assert_eq!(
+            count, 1,
+            "same peer reconnecting from different ephemeral ports must yield one series, got {count}"
+        );
+    }
+
+    /// 100 distinct peers connect, then all disconnect. Cardinality should
+    /// peak at the connected count and return to zero.
+    #[test]
+    fn discovered_peers_cardinality_tracks_connected_peers() {
+        let mut registry = Registry::default();
+        let mut metrics = Metrics::new(&mut registry);
+
+        let peers: Vec<_> = (0..100u16)
+            .map(|i| {
+                let id = libp2p::PeerId::random();
+                let info = peer_info(&format!("peer-{i}"), &format!("/ip4/10.0.0.{i}/tcp/26656"));
+                (id, info)
+            })
+            .collect();
+
+        for (id, info) in &peers {
+            metrics.record_new_peer(id, info);
+        }
+        assert_eq!(
+            discovered_peers_series_count(&registry),
+            peers.len(),
+            "one series per connected peer while connected"
+        );
+
+        for (id, info) in &peers {
+            metrics.free_slot(id, info);
+        }
+        assert_eq!(
+            discovered_peers_series_count(&registry),
+            0,
+            "all series must be pruned once every peer disconnects"
+        );
+    }
+
+    #[test]
+    fn peer_mesh_membership_pruned_on_leave() {
+        let mut registry = Registry::default();
+        let mut metrics = Metrics::new(&mut registry);
+        let peer_id = libp2p::PeerId::random();
+
+        let mut info = peer_info("peer-a", "/ip4/10.0.0.1/tcp/26656");
+        metrics.record_new_peer(&peer_id, &info);
+
+        let consensus: HashSet<String> = ["/consensus".to_string()].into_iter().collect();
+        let none: HashSet<String> = HashSet::new();
+
+        for _ in 0..200 {
+            // Join /consensus
+            metrics
+                .update_peer_metrics(&peer_id, &info, info.score, Some(consensus.clone()))
+                .unwrap();
+            info.topics = consensus.clone();
+
+            // Leave /consensus — entry must be removed, not zeroed
+            metrics
+                .update_peer_metrics(&peer_id, &info, info.score, Some(none.clone()))
+                .unwrap();
+            info.topics = none.clone();
+        }
+
+        assert_eq!(
+            metric_series_count(&registry, "peer_mesh_membership"),
+            0,
+            "leaving a topic mesh must prune the peer_mesh_membership entry"
+        );
+    }
+
+    #[test]
+    fn peer_mesh_membership_pruned_on_disconnect() {
+        let mut registry = Registry::default();
+        let mut metrics = Metrics::new(&mut registry);
+        let peer_id = libp2p::PeerId::random();
+
+        let topics: HashSet<String> = ["/consensus", "/liveness", "/proposal_parts"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let mut info = peer_info("peer-a", "/ip4/10.0.0.1/tcp/26656");
+        metrics.record_new_peer(&peer_id, &info);
+        metrics
+            .update_peer_metrics(&peer_id, &info, info.score, Some(topics.clone()))
+            .unwrap();
+        info.topics = topics;
+
+        assert_eq!(metric_series_count(&registry, "peer_mesh_membership"), 3);
+
+        metrics.free_slot(&peer_id, &info);
+
+        assert_eq!(
+            metric_series_count(&registry, "peer_mesh_membership"),
+            0,
+            "disconnect must prune all mesh-membership entries for the peer"
+        );
+    }
+
+    #[test]
+    fn explicit_peers_pruned_on_stale() {
+        let mut registry = Registry::default();
+        let metrics = Metrics::new(&mut registry);
+
+        for i in 0..200 {
+            let peer_id = libp2p::PeerId::random();
+            let moniker = format!("peer-{i}");
+            metrics.record_explicit_peer(&peer_id, &moniker);
+            metrics.mark_explicit_peer_stale(&peer_id, &moniker);
+        }
+
+        assert_eq!(
+            metric_series_count(&registry, "explicit_peers"),
+            0,
+            "marking an explicit peer stale must prune the entry"
+        );
     }
 }

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -620,7 +620,6 @@ where
     Ok(())
 }
 
-// When receiving an invalid value, re-request the whole batch from another peer.
 async fn on_invalid_value<Ctx>(
     co: Co<Ctx>,
     state: &mut State<Ctx>,
@@ -632,22 +631,7 @@ where
     Ctx: Context,
 {
     error!(%peer_id, %height, "Received invalid value");
-
-    state.peer_scorer.update_score(peer_id, SyncResult::Failure);
-
-    if let Some((request_id, stored_peer_id)) = state.get_request_id_by(height) {
-        if stored_peer_id != peer_id {
-            warn!(
-                %request_id, peer.actual = %peer_id, peer.expected = %stored_peer_id,
-                "Received response from different peer than expected"
-            );
-        }
-        re_request_values_from_peer_except(co, state, metrics, request_id, Some(peer_id)).await?;
-    } else {
-        error!(%peer_id, %height, "Received height of invalid value for unknown request");
-    }
-
-    Ok(())
+    penalize_peer_and_retry(co, state, metrics, peer_id, height).await
 }
 
 async fn on_value_processing_error<Ctx>(
@@ -661,14 +645,34 @@ where
     Ctx: Context,
 {
     error!(%peer_id, %height, "Error while processing value");
+    penalize_peer_and_retry(co, state, metrics, peer_id, height).await
+}
 
-    // NOTE: We do not update the peer score here, as this is an internal error
-    //       and not a failure from the peer's side.
+// Penalize the peer and re-request the batch covering `height` from a different peer.
+async fn penalize_peer_and_retry<Ctx>(
+    co: Co<Ctx>,
+    state: &mut State<Ctx>,
+    metrics: &Metrics,
+    peer_id: PeerId,
+    height: Ctx::Height,
+) -> Result<(), Error<Ctx>>
+where
+    Ctx: Context,
+{
+    state.peer_scorer.update_score(peer_id, SyncResult::Failure);
 
-    if let Some((request_id, _)) = state.get_request_id_by(height) {
-        re_request_values_from_peer_except(co, state, metrics, request_id, None).await?;
+    if let Some((request_id, stored_peer_id)) = state.get_request_id_by(height) {
+        if stored_peer_id != peer_id {
+            // Defensive check: `on_value_response` already rejects responses from
+            // a different peer than the one recorded in the pending entry.
+            error!(
+                %request_id, peer.actual = %peer_id, peer.expected = %stored_peer_id,
+                "Received response from different peer than expected"
+            );
+        }
+        re_request_values_from_peer_except(co, state, metrics, request_id, Some(peer_id)).await?;
     } else {
-        error!(%peer_id, %height, "Received height of invalid value for unknown request");
+        error!(%peer_id, %height, "Received height for unknown request");
     }
 
     Ok(())
@@ -2002,6 +2006,77 @@ mod tests {
         // sync_height should reset to the start of the failed range (11),
         // which is above tip_height (10).
         assert_eq!(state.sync_height, Height::new(11));
+    }
+
+    // -- on_value_processing_error: peer fault handling --
+
+    #[test]
+    fn test_value_processing_error_penalizes_peer_and_retries_via_other_peer() {
+        let mut state = make_test_state();
+        state.started = true;
+        let metrics = crate::Metrics::new(std::time::Duration::from_secs(10));
+
+        state.tip_height = Height::new(10);
+        state.sync_height = Height::new(16);
+
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+
+        state.peers.insert(
+            peer_a,
+            crate::Status {
+                peer_id: peer_a,
+                tip_height: Height::new(20),
+                history_min_height: Height::new(1),
+            },
+        );
+        state.peers.insert(
+            peer_b,
+            crate::Status {
+                peer_id: peer_b,
+                tip_height: Height::new(20),
+                history_min_height: Height::new(1),
+            },
+        );
+
+        state.pending_requests.insert(
+            OutboundRequestId::new("req1"),
+            PendingRequestEntry {
+                range: Height::new(11)..=Height::new(15),
+                peer: peer_a,
+                excluded_peers: BTreeSet::new(),
+            },
+        );
+
+        let initial_score = state.peer_scorer.get_score(&peer_a);
+
+        let effects = drive_input_with_retries(
+            &mut state,
+            &metrics,
+            Input::ValueProcessingError(peer_a, Height::new(11)),
+        )
+        .unwrap();
+
+        assert!(
+            state.peer_scorer.get_score(&peer_a) < initial_score,
+            "Peer A should be penalized for serving an undecodable value"
+        );
+
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SendValueRequest(..))),
+            "Expected a re-request after ValueProcessingError"
+        );
+
+        assert_eq!(state.pending_requests.len(), 1);
+        let (_, entry) = state.pending_requests.iter().next().unwrap();
+        assert_ne!(entry.peer, peer_a, "Retry should not go back to peer A");
+        assert_eq!(entry.peer, peer_b);
+        assert!(
+            entry.excluded_peers.contains(&peer_a),
+            "Peer A should be in the excluded set"
+        );
     }
 
     // -- on_value_response: certificate height validation --

--- a/code/crates/test/src/middleware.rs
+++ b/code/crates/test/src/middleware.rs
@@ -11,9 +11,9 @@ pub trait Middleware: fmt::Debug + Send + Sync {
         _ctx: &TestContext,
         _current_height: Height,
         _height: Height,
-        genesis: &Genesis,
+        _genesis: &Genesis,
     ) -> Option<ValidatorSet> {
-        Some(genesis.validator_set.clone())
+        None
     }
 
     fn get_timeouts(


### PR DESCRIPTION
## Summary

Brings 5 commits forward from a downstream fork of Malachite, on top of #1552.

## What's in here

**Sync**
- fix: penalize peer on value processing error
- fix: drop synced values whose id mismatches the commit certificate
- fix: Do not forward sync value to host if we have a decision

**Network**
- fix: break network loop on event channel send failure
- fix: Remove stale metric on peer disconnect

## Test plan

- [x] `cargo check --workspace --tests --all-features` passes locally
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)