### PR TITLE
docs: add missing crate readmes

### DIFF
--- a/code/crates/app-channel/README.md
+++ b/code/crates/app-channel/README.md
@@ -1,0 +1,7 @@
+# malachitebft-app-channel
+
+High-level interface for building channel-based applications on top of the
+Malachite BFT consensus engine.
+
+This crate provides a channel-oriented application integration layer for
+connecting application logic to Malachite.

--- a/code/crates/app/README.md
+++ b/code/crates/app/README.md
@@ -1,0 +1,7 @@
+# malachitebft-app
+
+High-level interface for building applications on top of the Malachite BFT
+consensus engine.
+
+This crate provides application-facing helpers and re-exports used to spawn and
+drive a Malachite-based node.

--- a/code/crates/codec/README.md
+++ b/code/crates/codec/README.md
@@ -1,0 +1,6 @@
+# malachitebft-codec
+
+Codec abstraction for the Malachite BFT consensus engine.
+
+This crate defines encoding and decoding traits used by Malachite components to
+serialize messages and other protocol data.

--- a/code/crates/config/README.md
+++ b/code/crates/config/README.md
@@ -1,0 +1,6 @@
+# malachitebft-config
+
+Configuration for the Malachite BFT consensus engine.
+
+This crate contains configuration types for consensus, networking, mempool,
+metrics, synchronization, and related runtime settings.

--- a/code/crates/core-driver/README.md
+++ b/code/crates/core-driver/README.md
@@ -1,0 +1,6 @@
+# malachitebft-core-driver
+
+Driver for the state machine of the Malachite BFT consensus engine.
+
+This crate coordinates the core state machine by feeding inputs, processing
+outputs, and connecting consensus progress to the rest of the engine.

--- a/code/crates/core-state-machine/README.md
+++ b/code/crates/core-state-machine/README.md
@@ -1,0 +1,6 @@
+# malachitebft-core-state-machine
+
+Core state machine for the Malachite BFT consensus engine.
+
+This crate contains the per-round consensus state machine used by Malachite's
+core consensus logic.

--- a/code/crates/core-types/README.md
+++ b/code/crates/core-types/README.md
@@ -1,0 +1,6 @@
+# malachitebft-core-types
+
+Core type definitions and interfaces for the Malachite BFT consensus engine.
+
+This crate defines shared consensus types such as votes, proposals,
+certificates, validator sets, heights, rounds, and context abstractions.

--- a/code/crates/core-votekeeper/README.md
+++ b/code/crates/core-votekeeper/README.md
@@ -1,0 +1,6 @@
+# malachitebft-core-votekeeper
+
+Voting system for the Malachite BFT consensus engine.
+
+This crate provides infrastructure for tracking votes and determining when
+voting thresholds are reached.

--- a/code/crates/engine-byzantine/README.md
+++ b/code/crates/engine-byzantine/README.md
@@ -1,0 +1,6 @@
+# malachitebft-engine-byzantine
+
+Byzantine behavior support for the Malachite BFT consensus engine.
+
+This crate provides testing utilities for simulating Byzantine behavior, such as
+intercepting outgoing network messages and applying fault-injection strategies.

--- a/code/crates/engine/README.md
+++ b/code/crates/engine/README.md
@@ -1,0 +1,6 @@
+# malachitebft-engine
+
+Implementation of the Malachite BFT consensus engine.
+
+This crate wires together consensus, networking, synchronization, WAL handling,
+metrics, and application interactions into the runtime engine.

--- a/code/crates/metrics/README.md
+++ b/code/crates/metrics/README.md
@@ -1,0 +1,6 @@
+# malachitebft-metrics
+
+Metrics for the Malachite BFT consensus engine.
+
+This crate defines metric types and helpers used by Malachite components to
+observe consensus, networking, and runtime behavior.

--- a/code/crates/network/README.md
+++ b/code/crates/network/README.md
@@ -1,0 +1,6 @@
+# malachitebft-network
+
+Networking layer for the Malachite BFT consensus engine.
+
+This crate provides peer management, gossip, discovery integration, request and
+response handling, and other network-facing functionality used by the engine.

--- a/code/crates/peer/README.md
+++ b/code/crates/peer/README.md
@@ -1,0 +1,6 @@
+# malachitebft-peer
+
+Peer definition for the Malachite BFT consensus engine.
+
+This crate defines peer identity types and helpers used by Malachite networking
+components.

--- a/code/crates/proto/README.md
+++ b/code/crates/proto/README.md
@@ -1,0 +1,6 @@
+# malachitebft-proto
+
+Protobuf abstraction for the Malachite BFT consensus engine.
+
+This crate contains protobuf-related traits and helpers used to convert between
+wire-format messages and Malachite types.

--- a/code/crates/signing-ecdsa/README.md
+++ b/code/crates/signing-ecdsa/README.md
@@ -1,0 +1,6 @@
+# malachitebft-signing-ecdsa
+
+Generic ECDSA signing scheme utilities for the Malachite BFT consensus engine.
+
+This crate provides reusable ECDSA signature, signing key, verifying key, and
+scheme abstractions parameterized by curve-specific implementations.

--- a/code/crates/signing-ed25519/README.md
+++ b/code/crates/signing-ed25519/README.md
@@ -1,0 +1,6 @@
+# malachitebft-signing-ed25519
+
+Ed25519 signing scheme for the Malachite BFT consensus engine.
+
+This crate provides Ed25519 public keys, private keys, signatures, and signing
+scheme utilities used by Malachite.

--- a/code/crates/signing/README.md
+++ b/code/crates/signing/README.md
@@ -1,0 +1,6 @@
+# malachitebft-signing
+
+Signing provider abstraction for the Malachite BFT consensus engine.
+
+This crate defines signing and verification traits used by consensus and
+networking components without tying them to a specific cryptographic scheme.

--- a/code/crates/sync/README.md
+++ b/code/crates/sync/README.md
@@ -1,0 +1,6 @@
+# malachitebft-sync
+
+Synchronization protocol for the Malachite BFT consensus engine.
+
+This crate implements synchronization support for catching up on values and
+certificates needed by consensus.

--- a/code/crates/test/README.md
+++ b/code/crates/test/README.md
@@ -1,0 +1,6 @@
+# malachitebft-test
+
+Testing framework for the Malachite consensus engine.
+
+This crate provides test support utilities used across Malachite crates and
+integration tests.

--- a/code/crates/wal/README.md
+++ b/code/crates/wal/README.md
@@ -1,0 +1,6 @@
+# malachitebft-wal
+
+Write-Ahead Log for the Malachite BFT consensus engine.
+
+This crate provides WAL types and logic used to persist consensus data for
+crash recovery.


### PR DESCRIPTION
## Summary

- Add README files for crates under code/crates that did not have one
- Keep the existing core-consensus and discovery READMEs unchanged
- Use short package-specific summaries based on each crate's current purpose

Closes #710

## Verification

- Confirmed every directory under code/crates now has a README.md`n- git diff --cached --check passed before commit

## Contribution eligibility

- Issue opened by a repository contributor
- No open PR found for #710 before starting
