### PR TITLE
chore: Port downstream fork commits upstream

### DIFF
--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -151,27 +151,11 @@ where
         return on_invalid_value_response(co, state, metrics, request_id, peer_id).await;
     }
 
-    // Verify that each value's certificate height matches its expected sequential position
-    let heights_sequential = response
-        .values
-        .iter()
-        .enumerate()
-        .all(|(i, value)| value.height().as_u64() == start.as_u64() + i as u64);
-
-    if !heights_sequential {
-        warn!(
-            %request_id, %peer_id,
-            "Received response with non-sequential certificate heights for range {}",
-            DisplayRange(requested_range),
-        );
-
-        return on_invalid_value_response(co, state, metrics, request_id, peer_id).await;
-    }
-
     if !validate_value_response_heights::<Ctx>(&response) {
         warn!(
             %request_id, %peer_id,
-            "Response contains non-contiguous heights"
+            "Received response with non-contiguous certificate heights for range {}",
+            DisplayRange(requested_range),
         );
 
         return on_invalid_value_response(co, state, metrics, request_id, peer_id).await;
@@ -1391,188 +1375,6 @@ mod tests {
         assert_eq!(clamped, tip_height..=tip_height);
     }
 
-    #[test]
-    fn test_validate_value_response_heights() {
-        let validate = validate_value_response_heights::<TestContext>;
-
-        // Valid: contiguous heights 5, 6, 7
-        let response = ValueResponse::new(
-            Height::new(5),
-            vec![
-                make_raw_decided_value(5),
-                make_raw_decided_value(6),
-                make_raw_decided_value(7),
-            ],
-        );
-        assert!(validate(&response));
-
-        // Valid: single value
-        let response = ValueResponse::new(Height::new(1), vec![make_raw_decided_value(1)]);
-        assert!(validate(&response));
-
-        // Valid: empty response
-        let response = ValueResponse::new(Height::new(1), vec![]);
-        assert!(validate(&response));
-
-        // Invalid: gap in heights (1, 2, 5 instead of 1, 2, 3)
-        let response = ValueResponse::new(
-            Height::new(1),
-            vec![
-                make_raw_decided_value(1),
-                make_raw_decided_value(2),
-                make_raw_decided_value(5),
-            ],
-        );
-        assert!(!validate(&response));
-
-        // Invalid: duplicate heights (1, 1, 2 instead of 1, 2, 3)
-        let response = ValueResponse::new(
-            Height::new(1),
-            vec![
-                make_raw_decided_value(1),
-                make_raw_decided_value(1),
-                make_raw_decided_value(2),
-            ],
-        );
-        assert!(!validate(&response));
-
-        // Invalid: first value doesn't match start_height
-        let response = ValueResponse::new(
-            Height::new(1),
-            vec![
-                make_raw_decided_value(2),
-                make_raw_decided_value(3),
-                make_raw_decided_value(4),
-            ],
-        );
-        assert!(!validate(&response));
-
-        // Invalid: reversed order (3, 2, 1 instead of 1, 2, 3)
-        let response = ValueResponse::new(
-            Height::new(1),
-            vec![
-                make_raw_decided_value(3),
-                make_raw_decided_value(2),
-                make_raw_decided_value(1),
-            ],
-        );
-        assert!(!validate(&response));
-    }
-
-    fn make_raw_decided_value(height: u64) -> RawDecidedValue<TestContext> {
-        RawDecidedValue {
-            value_bytes: Bytes::new(),
-            certificate: CommitCertificate {
-                height: Height::new(height),
-                round: Round::new(0),
-                value_id: ValueId::new(height),
-                commit_signatures: vec![],
-            },
-        }
-    }
-
-    /// Test that a non-contiguous sync response (e.g., request 1..=10, get 1,2,5..12)
-    /// is rejected by the sync state machine and triggers a re-request from another peer.
-    #[test]
-    fn test_non_contiguous_response_rejected_by_sync_handler() {
-        use std::cell::Cell;
-
-        let peer_a = PeerId::random();
-        let peer_b = PeerId::random();
-        let request_id = OutboundRequestId::new("req-1");
-
-        let mut state = State::<TestContext>::new(
-            Box::new(rand::rngs::StdRng::seed_from_u64(42)),
-            Config::default(),
-        );
-
-        // Set up state: consensus is at height 1, pending request for 1..=10 from peer_a
-        state.consensus_height = Height::new(1);
-        state.tip_height = Height::new(0);
-        state.sync_height = Height::new(11);
-        state.started = true;
-        state.pending_requests.insert(
-            request_id.clone(),
-            PendingRequestEntry {
-                range: Height::new(1)..=Height::new(10),
-                peer: peer_a,
-                excluded_peers: BTreeSet::new(),
-            },
-        );
-
-        // Add peer_b so re-request can find another peer
-        state.update_status(Status {
-            peer_id: peer_b,
-            tip_height: Height::new(20),
-            history_min_height: Height::new(1),
-        });
-
-        // Build a malformed response: 10 values starting at height 1
-        // but with a gap (heights 1, 2, 5, 6, 7, 8, 9, 10, 11, 12)
-        let response = ValueResponse::new(
-            Height::new(1),
-            vec![
-                make_raw_decided_value(1),
-                make_raw_decided_value(2),
-                make_raw_decided_value(5),
-                make_raw_decided_value(6),
-                make_raw_decided_value(7),
-                make_raw_decided_value(8),
-                make_raw_decided_value(9),
-                make_raw_decided_value(10),
-                make_raw_decided_value(11),
-                make_raw_decided_value(12),
-            ],
-        );
-
-        let input = Input::ValueResponse(request_id, peer_a, Some(response));
-        let metrics = Metrics::default();
-
-        // The handler should reject the response and re-request from another peer.
-        // It should yield SendValueRequest (to peer_b), NOT ProcessValueResponse.
-        let saw_send_request = Cell::new(false);
-        let saw_process_response = Cell::new(false);
-
-        let result: Result<(), Error<TestContext>> = (|| {
-            crate::process!(
-                input: input,
-                state: &mut state,
-                metrics: &metrics,
-                with: effect => {
-                    match &effect {
-                        Effect::SendValueRequest(peer, _, _) => {
-                            saw_send_request.set(true);
-                            assert_eq!(*peer, peer_b);
-                        }
-                        Effect::ProcessValueResponse(_, _, _, _) => {
-                            saw_process_response.set(true);
-                        }
-                        _ => {}
-                    }
-
-                    Ok::<_, eyre::Report>(match effect {
-                        Effect::SendValueRequest(_, _, r) => {
-                            r.resume_with(Some(OutboundRequestId::new("req-2")))
-                        }
-                        Effect::BroadcastStatus(_, r) => r.resume_with(()),
-                        Effect::SendValueResponse(_, _, r) => r.resume_with(()),
-                        Effect::GetDecidedValues(_, _, r) => r.resume_with(()),
-                        Effect::ProcessValueResponse(_, _, _, r) => r.resume_with(()),
-                    })
-                }
-            )
-        })();
-
-        assert!(result.is_ok(), "Handler returned error: {result:?}");
-        assert!(
-            saw_send_request.get(),
-            "Expected a re-request to another peer after non-contiguous response"
-        );
-        assert!(
-            !saw_process_response.get(),
-            "Non-contiguous response should NOT have been forwarded to consensus"
-        );
-    }
     // Helper: drive a handle::Input through the coroutine-based handler.
     // Collects all yielded effects and invokes `resume_strategy` to produce
     // the `Resume` value fed back for each yielded effect. Tests that do not
@@ -2134,138 +1936,6 @@ mod tests {
     }
 
     #[test]
-    fn test_value_response_accepts_sequential_heights() {
-        let (mut state, metrics, peer) = setup_response_test(10, 14);
-
-        let response = crate::ValueResponse::new(
-            Height::new(10),
-            vec![
-                make_raw_value(10),
-                make_raw_value(11),
-                make_raw_value(12),
-                make_raw_value(13),
-                make_raw_value(14),
-            ],
-        );
-
-        let effects = drive_input(
-            &mut state,
-            &metrics,
-            Input::ValueResponse(OutboundRequestId::new("req1"), peer, Some(response)),
-        )
-        .unwrap();
-
-        assert!(
-            has_process_value_response(&effects),
-            "Response with correct sequential heights should be accepted"
-        );
-    }
-
-    #[test]
-    fn test_value_response_rejects_duplicate_heights() {
-        let (mut state, metrics, peer) = setup_response_test(10, 14);
-
-        let response = crate::ValueResponse::new(
-            Height::new(10),
-            vec![
-                make_raw_value(10),
-                make_raw_value(10),
-                make_raw_value(10),
-                make_raw_value(10),
-                make_raw_value(14),
-            ],
-        );
-
-        let effects = drive_input(
-            &mut state,
-            &metrics,
-            Input::ValueResponse(OutboundRequestId::new("req1"), peer, Some(response)),
-        )
-        .unwrap();
-
-        assert!(
-            !has_process_value_response(&effects),
-            "Response with duplicate heights should be rejected"
-        );
-    }
-
-    #[test]
-    fn test_value_response_rejects_out_of_order_heights() {
-        let (mut state, metrics, peer) = setup_response_test(10, 14);
-
-        let response = crate::ValueResponse::new(
-            Height::new(10),
-            vec![
-                make_raw_value(10),
-                make_raw_value(11),
-                make_raw_value(13),
-                make_raw_value(12),
-                make_raw_value(14),
-            ],
-        );
-
-        let effects = drive_input(
-            &mut state,
-            &metrics,
-            Input::ValueResponse(OutboundRequestId::new("req1"), peer, Some(response)),
-        )
-        .unwrap();
-
-        assert!(
-            !has_process_value_response(&effects),
-            "Response with out-of-order heights should be rejected"
-        );
-    }
-
-    #[test]
-    fn test_value_response_rejects_heights_with_gaps() {
-        let (mut state, metrics, peer) = setup_response_test(10, 14);
-
-        // Heights [10, 11, 12, 14, 15] — gap at 13, extra 15
-        let response = crate::ValueResponse::new(
-            Height::new(10),
-            vec![
-                make_raw_value(10),
-                make_raw_value(11),
-                make_raw_value(12),
-                make_raw_value(14),
-                make_raw_value(15),
-            ],
-        );
-
-        let effects = drive_input(
-            &mut state,
-            &metrics,
-            Input::ValueResponse(OutboundRequestId::new("req1"), peer, Some(response)),
-        )
-        .unwrap();
-
-        assert!(
-            !has_process_value_response(&effects),
-            "Response with gaps in heights should be rejected"
-        );
-    }
-
-    #[test]
-    fn test_value_response_accepts_single_value() {
-        let (mut state, metrics, peer) = setup_response_test(10, 10);
-
-        let response = crate::ValueResponse::new(Height::new(10), vec![make_raw_value(10)]);
-
-        let effects = drive_input(
-            &mut state,
-            &metrics,
-            Input::ValueResponse(OutboundRequestId::new("req1"), peer, Some(response)),
-        )
-        .unwrap();
-
-        assert!(
-            has_process_value_response(&effects),
-            "Response with a single value at the correct height should be accepted"
-        );
-    }
-
-    #[test]
     fn test_value_response_rejects_wrong_start_height() {
         // Requested range 10..=14, but peer sends sequential values starting at 5
         let (mut state, metrics, peer) = setup_response_test(10, 14);
@@ -2712,5 +2382,188 @@ mod tests {
                 "No pending request should cover the un-retried suffix start",
             );
         }
+    }
+
+    #[test]
+    fn test_validate_value_response_heights() {
+        let validate = validate_value_response_heights::<TestContext>;
+
+        // Valid: contiguous heights 5, 6, 7
+        let response = ValueResponse::new(
+            Height::new(5),
+            vec![
+                make_raw_decided_value(5),
+                make_raw_decided_value(6),
+                make_raw_decided_value(7),
+            ],
+        );
+        assert!(validate(&response));
+
+        // Valid: single value
+        let response = ValueResponse::new(Height::new(1), vec![make_raw_decided_value(1)]);
+        assert!(validate(&response));
+
+        // Valid: empty response
+        let response = ValueResponse::new(Height::new(1), vec![]);
+        assert!(validate(&response));
+
+        // Invalid: gap in heights (1, 2, 5 instead of 1, 2, 3)
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(1),
+                make_raw_decided_value(2),
+                make_raw_decided_value(5),
+            ],
+        );
+        assert!(!validate(&response));
+
+        // Invalid: duplicate heights (1, 1, 2 instead of 1, 2, 3)
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(1),
+                make_raw_decided_value(1),
+                make_raw_decided_value(2),
+            ],
+        );
+        assert!(!validate(&response));
+
+        // Invalid: first value doesn't match start_height
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(2),
+                make_raw_decided_value(3),
+                make_raw_decided_value(4),
+            ],
+        );
+        assert!(!validate(&response));
+
+        // Invalid: reversed order (3, 2, 1 instead of 1, 2, 3)
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(3),
+                make_raw_decided_value(2),
+                make_raw_decided_value(1),
+            ],
+        );
+        assert!(!validate(&response));
+    }
+
+    fn make_raw_decided_value(height: u64) -> RawDecidedValue<TestContext> {
+        RawDecidedValue {
+            value_bytes: Bytes::new(),
+            certificate: CommitCertificate {
+                height: Height::new(height),
+                round: Round::new(0),
+                value_id: ValueId::new(height),
+                commit_signatures: vec![],
+            },
+        }
+    }
+
+    /// Test that a non-contiguous sync response (e.g., request 1..=10, get 1,2,5..12)
+    /// is rejected by the sync state machine and triggers a re-request from another peer.
+    #[test]
+    fn test_non_contiguous_response_rejected_by_sync_handler() {
+        use std::cell::Cell;
+
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+        let request_id = OutboundRequestId::new("req-1");
+
+        let mut state = State::<TestContext>::new(
+            Box::new(rand::rngs::StdRng::seed_from_u64(42)),
+            Config::default(),
+        );
+
+        // Set up state: consensus is at height 1, pending request for 1..=10 from peer_a
+        state.consensus_height = Height::new(1);
+        state.tip_height = Height::new(0);
+        state.sync_height = Height::new(11);
+        state.started = true;
+        state.pending_requests.insert(
+            request_id.clone(),
+            PendingRequestEntry {
+                range: Height::new(1)..=Height::new(10),
+                peer: peer_a,
+                excluded_peers: BTreeSet::new(),
+            },
+        );
+
+        // Add peer_b so re-request can find another peer
+        state.update_status(Status {
+            peer_id: peer_b,
+            tip_height: Height::new(20),
+            history_min_height: Height::new(1),
+        });
+
+        // Build a malformed response: 10 values starting at height 1
+        // but with a gap (heights 1, 2, 5, 6, 7, 8, 9, 10, 11, 12)
+        let response = ValueResponse::new(
+            Height::new(1),
+            vec![
+                make_raw_decided_value(1),
+                make_raw_decided_value(2),
+                make_raw_decided_value(5),
+                make_raw_decided_value(6),
+                make_raw_decided_value(7),
+                make_raw_decided_value(8),
+                make_raw_decided_value(9),
+                make_raw_decided_value(10),
+                make_raw_decided_value(11),
+                make_raw_decided_value(12),
+            ],
+        );
+
+        let input = Input::ValueResponse(request_id, peer_a, Some(response));
+        let metrics = Metrics::default();
+
+        // The handler should reject the response and re-request from another peer.
+        // It should yield SendValueRequest (to peer_b), NOT ProcessValueResponse.
+        let saw_send_request = Cell::new(false);
+        let saw_process_response = Cell::new(false);
+
+        let result: Result<(), Error<TestContext>> = (|| {
+            crate::process!(
+                input: input,
+                state: &mut state,
+                metrics: &metrics,
+                with: effect => {
+                    match &effect {
+                        Effect::SendValueRequest(peer, _, _) => {
+                            saw_send_request.set(true);
+                            assert_eq!(*peer, peer_b);
+                        }
+                        Effect::ProcessValueResponse(_, _, _, _) => {
+                            saw_process_response.set(true);
+                        }
+                        _ => {}
+                    }
+
+                    Ok::<_, eyre::Report>(match effect {
+                        Effect::SendValueRequest(_, _, r) => {
+                            r.resume_with(Some(OutboundRequestId::new("req-2")))
+                        }
+                        Effect::BroadcastStatus(_, r) => r.resume_with(()),
+                        Effect::SendValueResponse(_, _, r) => r.resume_with(()),
+                        Effect::GetDecidedValues(_, _, r) => r.resume_with(()),
+                        Effect::ProcessValueResponse(_, _, _, r) => r.resume_with(()),
+                    })
+                }
+            )
+        })();
+
+        assert!(result.is_ok(), "Handler returned error: {result:?}");
+        assert!(
+            saw_send_request.get(),
+            "Expected a re-request to another peer after non-contiguous response"
+        );
+        assert!(
+            !saw_process_response.get(),
+            "Non-contiguous response should NOT have been forwarded to consensus"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Brings 1 commit forward from a downstream fork of Malachite, on top of #1553.

## What's in here

**Sync**
- refactor: remove duplicate height validation in `on_value_response`

`on_value_response` ran two equivalent height-contiguity checks back-to-back: an inline `heights_sequential` block and the helper-based `validate_value_response_heights()` call. This collapses them to a single helper call. The remaining warning consistently uses "non-contiguous" and includes the requested range via `DisplayRange`. The 5 inline tests covering the deleted block are removed; `test_validate_value_response_heights` and `test_non_contiguous_response_rejected_by_sync_handler` continue to cover the same cases.

## Test plan

- [x] `cargo check --workspace --tests --all-features` passes locally
- [x] `cargo nextest run -p arc-malachitebft-sync` passes locally (44/44, 1 skipped)
- [x] `cargo fmt --all --check` clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)