### PR TITLE
ci(pr-gate): bug fixes, vouch-style allow/deny, extracted scripts

### DIFF
--- a/.github/DENOUNCED
+++ b/.github/DENOUNCED
@@ -1,0 +1,12 @@
+# Denounced contributors.
+#
+# Users listed here have their pull requests automatically closed by the
+# PR Gate workflow regardless of any other signal (codeowner status, org
+# membership, repo collaborator role, issue assignment, /assign tag).
+#
+# Format: one GitHub username per line, with an optional reason after a
+# colon. Comments start with `#`. Blank lines are ignored.
+#
+# Example:
+#   baduser
+#   spammer: opens AI-generated PRs that ignore review feedback

--- a/.github/VOUCHED
+++ b/.github/VOUCHED
@@ -1,0 +1,18 @@
+# Vouched contributors.
+#
+# Users listed here bypass the issue-assignment requirement of the PR
+# Gate workflow. Their pull requests are admitted as if they were org
+# members or repo collaborators. This is the path for trusted external
+# contributors who have demonstrated they understand the project well
+# enough that requiring a fresh issue claim for every PR is overhead.
+#
+# Codeowners, repo collaborators, and circlefin org members are already
+# trusted through earlier checks — they do not need to be vouched here.
+#
+# Format: one GitHub username per line, with an optional reason after a
+# colon for maintainer reference. Comments start with `#`. Blank lines
+# are ignored.
+#
+# Example:
+#   trusted-contributor
+#   long-time-helper: maintainer of the upstream foo crate

--- a/.github/pr-gate-messages/default.md
+++ b/.github/pr-gate-messages/default.md
@@ -1,0 +1,7 @@
+Hi @{{prAuthor}},
+
+Thank you for your interest in contributing to Malachite.
+
+This PR has been automatically closed because it does not meet our contribution requirements.
+
+Please see our [CONTRIBUTING.md](https://github.com/{{owner}}/{{repo}}/blob/main/CONTRIBUTING.md) for details on how to contribute properly.

--- a/.github/pr-gate-messages/denounced.md
+++ b/.github/pr-gate-messages/denounced.md
@@ -1,0 +1,5 @@
+Hi @{{prAuthor}},
+
+This PR has been automatically closed because you are listed in this repository's [`DENOUNCED`](https://github.com/{{owner}}/{{repo}}/blob/main/.github/DENOUNCED) file.{{reasonBlock}}
+
+If you believe this is in error, please reach out to the maintainers.

--- a/.github/pr-gate-messages/issue_not_found.md
+++ b/.github/pr-gate-messages/issue_not_found.md
@@ -1,0 +1,12 @@
+Hi @{{prAuthor}},
+
+Thank you for your interest in contributing to Malachite.
+
+This PR has been automatically closed because the referenced issue could not be found. Please ensure you reference a valid, existing issue using the format `Closes: #XXX`.
+
+**To contribute properly:**
+1. Find an existing issue you'd like to work on, or [open a new issue](https://github.com/{{owner}}/{{repo}}/issues/new) describing your proposed change
+2. Comment on the issue requesting assignment and wait for maintainer approval
+3. Only submit a PR after you have been assigned to the issue
+
+Please see our [CONTRIBUTING.md](https://github.com/{{owner}}/{{repo}}/blob/main/CONTRIBUTING.md) for more details.

--- a/.github/pr-gate-messages/no_issue_reference.md
+++ b/.github/pr-gate-messages/no_issue_reference.md
@@ -1,0 +1,12 @@
+Hi @{{prAuthor}},
+
+Thank you for your interest in contributing to Malachite.
+
+This PR has been automatically closed because it does not reference a GitHub issue. All PRs must reference an existing issue using the format `Closes: #XXX`.
+
+**To contribute properly:**
+1. Find an existing issue you'd like to work on, or [open a new issue](https://github.com/{{owner}}/{{repo}}/issues/new) describing your proposed change
+2. Comment on the issue requesting assignment and wait for maintainer approval
+3. Only submit a PR after you have been assigned to the issue
+
+Please see our [CONTRIBUTING.md](https://github.com/{{owner}}/{{repo}}/blob/main/CONTRIBUTING.md) for more details.

--- a/.github/pr-gate-messages/not_assigned_to_issue.md
+++ b/.github/pr-gate-messages/not_assigned_to_issue.md
@@ -1,0 +1,12 @@
+Hi @{{prAuthor}},
+
+Thank you for your interest in contributing to Malachite.
+
+This PR has been automatically closed because you are not assigned to issue #{{issueNumber}}. We require contributors to be explicitly assigned to an issue before submitting a PR.
+
+**To contribute properly:**
+1. Comment on issue #{{issueNumber}} requesting assignment
+2. Wait for maintainer approval
+3. Only submit a PR after you have been assigned
+
+Please see our [CONTRIBUTING.md](https://github.com/{{owner}}/{{repo}}/blob/main/CONTRIBUTING.md) for more details.

--- a/.github/scripts/pr-gate/close.js
+++ b/.github/scripts/pr-gate/close.js
@@ -1,0 +1,95 @@
+// Close-action for the PR Gate workflow.
+//
+// Reads a markdown template from the base ref of the repo, substitutes
+// {{placeholder}} variables, posts the rendered message as a comment,
+// labels the PR `need-triage`, then closes the PR.
+//
+// Templates live under .github/pr-gate-messages/ and the template name
+// equals the rejection reason emitted by evaluate.js — falls back to
+// `default.md` for unknown reasons.
+
+const FALLBACK_TEMPLATE = 'Hi @{{prAuthor}}, this PR was closed because it does not meet our contribution requirements. See CONTRIBUTING.md.';
+
+const KNOWN_TEMPLATES = new Set([
+  'denounced',
+  'no_issue_reference',
+  'not_assigned_to_issue',
+  'issue_not_found',
+]);
+
+function renderTemplate(template, vars) {
+  return Object.entries(vars).reduce(
+    (acc, [k, v]) => acc.replaceAll(`{{${k}}}`, v),
+    template,
+  );
+}
+
+function pickTemplateName(reason) {
+  return KNOWN_TEMPLATES.has(reason) ? reason : 'default';
+}
+
+function buildVars({ prAuthor, issueNumber, owner, repo, denounceReason }) {
+  return {
+    prAuthor,
+    issueNumber,
+    owner,
+    repo,
+    reasonBlock: denounceReason ? ` Reason: ${denounceReason}.` : '',
+  };
+}
+
+async function close({ github, context, core, inputs }) {
+  const { reason, issueNumber, denounceReason } = inputs;
+  const prAuthor = context.payload.pull_request.user.login;
+  const { owner, repo } = context.repo;
+
+  const templateName = pickTemplateName(reason);
+
+  let template;
+  try {
+    const response = await github.rest.repos.getContent({
+      owner,
+      repo,
+      path: `.github/pr-gate-messages/${templateName}.md`,
+      ref: context.payload.pull_request.base.ref,
+    });
+    template = Buffer.from(response.data.content, 'base64').toString('utf-8');
+  } catch (error) {
+    core.info(`Could not load template ${templateName}.md: ${error.message}`);
+    template = FALLBACK_TEMPLATE;
+  }
+
+  const message = renderTemplate(
+    template,
+    buildVars({ prAuthor, issueNumber, owner, repo, denounceReason }),
+  );
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: context.payload.pull_request.number,
+    body: message,
+  });
+
+  try {
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: context.payload.pull_request.number,
+      labels: ['need-triage'],
+    });
+  } catch (error) {
+    core.info(`Could not add label (may not exist): ${error.message}`);
+  }
+
+  await github.rest.pulls.update({
+    owner,
+    repo,
+    pull_number: context.payload.pull_request.number,
+    state: 'closed',
+  });
+
+  core.info('PR closed successfully');
+}
+
+module.exports = { close, renderTemplate, pickTemplateName, buildVars, KNOWN_TEMPLATES };

--- a/.github/scripts/pr-gate/close.test.js
+++ b/.github/scripts/pr-gate/close.test.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  renderTemplate,
+  pickTemplateName,
+  buildVars,
+  KNOWN_TEMPLATES,
+} = require('./close');
+
+test('renderTemplate: substitutes single placeholder', () => {
+  assert.equal(
+    renderTemplate('Hi @{{prAuthor}}!', { prAuthor: 'alice' }),
+    'Hi @alice!',
+  );
+});
+
+test('renderTemplate: substitutes multiple placeholders, repeated', () => {
+  const out = renderTemplate(
+    '{{owner}}/{{repo}} — see {{owner}}/{{repo}}/blob/main',
+    { owner: 'circlefin', repo: 'malachite' },
+  );
+  assert.equal(out, 'circlefin/malachite — see circlefin/malachite/blob/main');
+});
+
+test('renderTemplate: missing placeholder is left literal', () => {
+  // We don't pre-validate — placeholders in templates that aren't in vars
+  // pass through, which is intentional so non-overlapping templates can
+  // share a single vars object.
+  assert.equal(
+    renderTemplate('Hi @{{prAuthor}}, issue #{{issueNumber}}', {
+      prAuthor: 'alice',
+    }),
+    'Hi @alice, issue #{{issueNumber}}',
+  );
+});
+
+test('pickTemplateName: known reason returned verbatim', () => {
+  for (const reason of KNOWN_TEMPLATES) {
+    assert.equal(pickTemplateName(reason), reason);
+  }
+});
+
+test('pickTemplateName: unknown reason falls back to default', () => {
+  assert.equal(pickTemplateName('something-else'), 'default');
+  assert.equal(pickTemplateName(''), 'default');
+  assert.equal(pickTemplateName(undefined), 'default');
+});
+
+test('buildVars: includes reasonBlock when denounceReason provided', () => {
+  const v = buildVars({
+    prAuthor: 'a',
+    issueNumber: '1',
+    owner: 'o',
+    repo: 'r',
+    denounceReason: 'spammer',
+  });
+  assert.equal(v.reasonBlock, ' Reason: spammer.');
+});
+
+test('buildVars: omits reasonBlock when no denounceReason', () => {
+  const v = buildVars({
+    prAuthor: 'a',
+    issueNumber: '1',
+    owner: 'o',
+    repo: 'r',
+    denounceReason: '',
+  });
+  assert.equal(v.reasonBlock, '');
+});

--- a/.github/scripts/pr-gate/evaluate.js
+++ b/.github/scripts/pr-gate/evaluate.js
@@ -1,0 +1,178 @@
+// Eligibility evaluator for the PR Gate workflow.
+//
+// Runs inside actions/github-script. Reads every contributor-trust input
+// from the base ref via the REST API so a malicious PR can't substitute
+// content; the local checkout is only used to locate this script file.
+//
+// Emits two outputs:
+//   - status: 'allow' | 'close'
+//   - reason: bot | codeowner | collaborator | org_member | vouched |
+//             assigned | tagged_by_codeowner       (when status=allow)
+//             denounced | no_issue_reference |
+//             not_assigned_to_issue | issue_not_found  (when status=close)
+//
+// May also emit:
+//   - denounce_reason: free-text from the DENOUNCED file
+//   - issue_number:    stringified issue number when relevant
+
+const ALLOWED_BOTS = new Set(['dependabot[bot]', 'stepsecurity-app[bot]']);
+const ORG = 'circlefin';
+const ISSUE_PREFIXES = ['closes', 'fixes', 'fix', 'close', 'resolve', 'resolves'];
+const ISSUE_REF_REGEX = new RegExp(`(?:${ISSUE_PREFIXES.join('|')}):?\\s*#(\\d+)`, 'i');
+// Match @username; negative lookahead skips @org/team handles so they
+// aren't truncated to just @org. \b prevents matches ending in a hyphen.
+const CODEOWNER_HANDLE_REGEX = /@[\w-]+(?!\/)\b/g;
+const ASSIGN_PATTERN = /\/assign((?:\s+@[\w-]+)+)/gi;
+const USER_PATTERN = /@([\w-]+)/g;
+
+// Parse one-username-per-line list with `#` comments and optional `: reason`.
+// Returns Map<usernameLower, reasonString>.
+function parseList(content) {
+  const map = new Map();
+  if (!content) return map;
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const colonIdx = line.indexOf(':');
+    const name = (colonIdx === -1 ? line : line.slice(0, colonIdx)).trim().toLowerCase();
+    const reason = colonIdx === -1 ? '' : line.slice(colonIdx + 1).trim();
+    if (name) map.set(name, reason);
+  }
+  return map;
+}
+
+// Extract individual codeowner handles from a CODEOWNERS file body.
+// Team handles (@org/team) are skipped — they'd need separate expansion.
+function parseCodeowners(content) {
+  if (!content) return [];
+  return (content.match(CODEOWNER_HANDLE_REGEX) || []).map((c) => c.substring(1).toLowerCase());
+}
+
+// Collect every @user that any codeowner has /assign'd anywhere in the
+// thread. Union across comments (A's /assign @alice does not invalidate
+// B's earlier /assign @bob) and within each comment (`/assign @alice @bob`
+// and multiple /assign lines both contribute).
+function collectTaggedUsers(comments, codeowners, log = () => {}) {
+  const codeownerSet = new Set(codeowners);
+  const tagged = new Set();
+  for (const comment of comments) {
+    const author = comment.user.login.toLowerCase();
+    if (!codeownerSet.has(author)) continue;
+    for (const assignMatch of comment.body.matchAll(ASSIGN_PATTERN)) {
+      for (const userMatch of assignMatch[1].matchAll(USER_PATTERN)) {
+        tagged.add(userMatch[1].toLowerCase());
+        log(`/assign @${userMatch[1]} from codeowner @${comment.user.login} (${comment.html_url})`);
+      }
+    }
+  }
+  return tagged;
+}
+
+async function evaluate({ github, context, core }) {
+  const prAuthor = context.payload.pull_request.user.login;
+  const prAuthorLower = prAuthor.toLowerCase();
+  const prBody = context.payload.pull_request.body || '';
+  const { owner, repo } = context.repo;
+  const baseRef = context.payload.pull_request.base.ref;
+
+  async function readBaseFile(path) {
+    try {
+      const response = await github.rest.repos.getContent({ owner, repo, path, ref: baseRef });
+      return Buffer.from(response.data.content, 'base64').toString('utf-8');
+    } catch (error) {
+      core.info(`Could not read ${path} from ${baseRef}: ${error.message}`);
+      return null;
+    }
+  }
+
+  function decide(status, reason, extras = {}) {
+    core.info(`Decision: ${status} (${reason})`);
+    core.setOutput('status', status);
+    core.setOutput('reason', reason);
+    for (const [k, v] of Object.entries(extras)) {
+      core.setOutput(k, v);
+    }
+  }
+
+  // 1. Denounce list overrides everything else.
+  const denounced = parseList(await readBaseFile('.github/DENOUNCED'));
+  if (denounced.has(prAuthorLower)) {
+    return decide('close', 'denounced', { denounce_reason: denounced.get(prAuthorLower) });
+  }
+
+  // 2. Allowed bots.
+  if (ALLOWED_BOTS.has(prAuthor)) {
+    return decide('allow', 'bot');
+  }
+
+  // 3. Codeowner.
+  const codeowners = parseCodeowners(await readBaseFile('.github/CODEOWNERS'));
+  if (codeowners.includes(prAuthorLower)) {
+    return decide('allow', 'codeowner');
+  }
+
+  // 4. Repo collaborator (any access level: read/triage/write/admin).
+  try {
+    await github.rest.repos.checkCollaborator({ owner, repo, username: prAuthor });
+    return decide('allow', 'collaborator');
+  } catch (error) {
+    core.info(`${prAuthor} is not a collaborator: ${error.status}`);
+  }
+
+  // 5. Org member.
+  try {
+    await github.rest.orgs.checkMembershipForUser({ org: ORG, username: prAuthor });
+    return decide('allow', 'org_member');
+  } catch (error) {
+    core.info(`${prAuthor} is not a member of ${ORG}: ${error.status}`);
+  }
+
+  // 6. Vouched list.
+  const vouched = parseList(await readBaseFile('.github/VOUCHED'));
+  if (vouched.has(prAuthorLower)) {
+    return decide('allow', 'vouched');
+  }
+
+  // 7. Issue reference + assignment.
+  const issueMatch = prBody.match(ISSUE_REF_REGEX);
+  if (!issueMatch) {
+    return decide('close', 'no_issue_reference');
+  }
+  const issueNumber = parseInt(issueMatch[1], 10);
+
+  let issue;
+  try {
+    issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+  } catch (error) {
+    core.info(`Could not fetch issue #${issueNumber}: ${error.message}`);
+    return decide('close', 'issue_not_found', { issue_number: String(issueNumber) });
+  }
+
+  const assignees = issue.data.assignees.map((a) => a.login.toLowerCase());
+  if (assignees.includes(prAuthorLower)) {
+    return decide('allow', 'assigned', { issue_number: String(issueNumber) });
+  }
+
+  // 8. /assign @user from any codeowner.
+  if (codeowners.length > 0) {
+    try {
+      const comments = await github.paginate(github.rest.issues.listComments, {
+        owner,
+        repo,
+        issue_number: issueNumber,
+        per_page: 100,
+      });
+      const tagged = collectTaggedUsers(comments, codeowners, (m) => core.info(m));
+      if (tagged.has(prAuthorLower)) {
+        return decide('allow', 'tagged_by_codeowner', { issue_number: String(issueNumber) });
+      }
+      core.info(`No /assign @${prAuthor} from any codeowner. Tagged set: ${[...tagged].join(', ') || '(none)'}`);
+    } catch (error) {
+      core.info(`Error fetching comments for issue #${issueNumber}: ${error.message}`);
+    }
+  }
+
+  return decide('close', 'not_assigned_to_issue', { issue_number: String(issueNumber) });
+}
+
+module.exports = { evaluate, parseList, parseCodeowners, collectTaggedUsers };

--- a/.github/scripts/pr-gate/evaluate.test.js
+++ b/.github/scripts/pr-gate/evaluate.test.js
@@ -1,0 +1,345 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  evaluate,
+  parseList,
+  parseCodeowners,
+  collectTaggedUsers,
+} = require('./evaluate');
+
+// Build a fake { github, context, core } trio plus captured outputs.
+// Defaults give a not-bot non-trusted user with no issue reference, which
+// the evaluator will reject. Override anything per-test.
+function makeMocks(overrides = {}) {
+  const {
+    prAuthor = 'someone',
+    prBody = '',
+    files = {},
+    isCollaborator = false,
+    isOrgMember = false,
+    issueData = null,
+    issueFetchError = null,
+    comments = [],
+  } = overrides;
+
+  const outputs = {};
+  const logs = [];
+  const core = {
+    setOutput: (k, v) => {
+      outputs[k] = String(v);
+    },
+    info: (m) => logs.push(m),
+  };
+
+  const listComments = async () => comments;
+
+  const github = {
+    rest: {
+      repos: {
+        getContent: async ({ path }) => {
+          if (!(path in files) || files[path] == null) {
+            const err = new Error(`Not found: ${path}`);
+            err.status = 404;
+            throw err;
+          }
+          return {
+            data: { content: Buffer.from(files[path]).toString('base64') },
+          };
+        },
+        checkCollaborator: async () => {
+          if (!isCollaborator) {
+            const err = new Error('not a collaborator');
+            err.status = 404;
+            throw err;
+          }
+        },
+      },
+      orgs: {
+        checkMembershipForUser: async () => {
+          if (!isOrgMember) {
+            const err = new Error('not a member');
+            err.status = 404;
+            throw err;
+          }
+        },
+      },
+      issues: {
+        get: async () => {
+          if (issueFetchError) throw issueFetchError;
+          if (!issueData) {
+            const err = new Error('issue not found');
+            err.status = 404;
+            throw err;
+          }
+          return { data: issueData };
+        },
+        listComments,
+      },
+    },
+    paginate: async (method) => {
+      if (method === listComments) return comments;
+      return [];
+    },
+  };
+
+  const context = {
+    repo: { owner: 'circlefin', repo: 'malachite' },
+    payload: {
+      pull_request: {
+        user: { login: prAuthor },
+        body: prBody,
+        base: { ref: 'main' },
+        number: 999,
+      },
+    },
+  };
+
+  return { github, context, core, outputs, logs };
+}
+
+// ---------------------------------------------------------------------------
+// parseList
+// ---------------------------------------------------------------------------
+
+test('parseList: empty content yields empty map', () => {
+  assert.equal(parseList('').size, 0);
+  assert.equal(parseList(null).size, 0);
+  assert.equal(parseList(undefined).size, 0);
+});
+
+test('parseList: skips blank lines and # comments', () => {
+  const m = parseList('# comment\n\n  \nalice\n# inline-looking\n');
+  assert.deepEqual([...m.keys()], ['alice']);
+});
+
+test('parseList: usernames are lowercased', () => {
+  const m = parseList('Alice\nBOB');
+  assert.deepEqual([...m.keys()], ['alice', 'bob']);
+});
+
+test('parseList: optional `: reason` captured and trimmed', () => {
+  const m = parseList('alice: opens AI slop\nbob');
+  assert.equal(m.get('alice'), 'opens AI slop');
+  assert.equal(m.get('bob'), '');
+});
+
+test('parseList: reason with colon character is preserved', () => {
+  const m = parseList('alice: link: https://example.com');
+  assert.equal(m.get('alice'), 'link: https://example.com');
+});
+
+// ---------------------------------------------------------------------------
+// parseCodeowners
+// ---------------------------------------------------------------------------
+
+test('parseCodeowners: extracts @username handles, lowercased', () => {
+  assert.deepEqual(parseCodeowners('* @Alice @Bob'), ['alice', 'bob']);
+});
+
+test('parseCodeowners: skips @org/team handles (not truncated to @org)', () => {
+  assert.deepEqual(parseCodeowners('* @circlefin/team @alice'), ['alice']);
+});
+
+test('parseCodeowners: trailing hyphens are stripped', () => {
+  assert.deepEqual(parseCodeowners('* @alice- @bob'), ['alice', 'bob']);
+});
+
+test('parseCodeowners: empty content yields empty array', () => {
+  assert.deepEqual(parseCodeowners(''), []);
+  assert.deepEqual(parseCodeowners(null), []);
+});
+
+// ---------------------------------------------------------------------------
+// collectTaggedUsers
+// ---------------------------------------------------------------------------
+
+function comment(login, body, url = 'https://example.com/c') {
+  return { user: { login }, body, html_url: url };
+}
+
+test('collectTaggedUsers: ignores comments from non-codeowners', () => {
+  const tagged = collectTaggedUsers(
+    [comment('outsider', '/assign @alice')],
+    ['codeowner1'],
+  );
+  assert.equal(tagged.size, 0);
+});
+
+test('collectTaggedUsers: picks up single /assign from codeowner', () => {
+  const tagged = collectTaggedUsers(
+    [comment('codeowner1', '/assign @alice')],
+    ['codeowner1'],
+  );
+  assert.deepEqual([...tagged], ['alice']);
+});
+
+test('collectTaggedUsers: multiple users per /assign command', () => {
+  const tagged = collectTaggedUsers(
+    [comment('codeowner1', '/assign @alice @bob')],
+    ['codeowner1'],
+  );
+  assert.deepEqual([...tagged].sort(), ['alice', 'bob']);
+});
+
+test('collectTaggedUsers: composes across multiple codeowner comments', () => {
+  // Reproduces the original bug: codeowner A's later /assign @alice should
+  // NOT invalidate codeowner B's earlier /assign @bob.
+  const tagged = collectTaggedUsers(
+    [
+      comment('codeowner1', '/assign @bob'),
+      comment('codeowner2', '/assign @alice'),
+    ],
+    ['codeowner1', 'codeowner2'],
+  );
+  assert.deepEqual([...tagged].sort(), ['alice', 'bob']);
+});
+
+test('collectTaggedUsers: multiple /assign lines in one comment both register', () => {
+  const tagged = collectTaggedUsers(
+    [comment('codeowner1', '/assign @alice\n\nLater: /assign @bob')],
+    ['codeowner1'],
+  );
+  assert.deepEqual([...tagged].sort(), ['alice', 'bob']);
+});
+
+// ---------------------------------------------------------------------------
+// evaluate (full decision tree)
+// ---------------------------------------------------------------------------
+
+test('evaluate: denounced user → close denounced (with reason)', async () => {
+  const m = makeMocks({
+    prAuthor: 'baduser',
+    files: { '.github/DENOUNCED': 'baduser: spammer' },
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'close');
+  assert.equal(m.outputs.reason, 'denounced');
+  assert.equal(m.outputs.denounce_reason, 'spammer');
+});
+
+test('evaluate: denounce overrides even codeowner status', async () => {
+  // If you somehow end up in both files, denounce wins.
+  const m = makeMocks({
+    prAuthor: 'alice',
+    files: {
+      '.github/DENOUNCED': 'alice',
+      '.github/CODEOWNERS': '* @alice',
+    },
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'close');
+  assert.equal(m.outputs.reason, 'denounced');
+});
+
+test('evaluate: allowed bot → allow bot', async () => {
+  const m = makeMocks({ prAuthor: 'dependabot[bot]' });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'allow');
+  assert.equal(m.outputs.reason, 'bot');
+});
+
+test('evaluate: codeowner → allow codeowner', async () => {
+  const m = makeMocks({
+    prAuthor: 'alice',
+    files: { '.github/CODEOWNERS': '* @alice @bob' },
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'allow');
+  assert.equal(m.outputs.reason, 'codeowner');
+});
+
+test('evaluate: collaborator → allow collaborator', async () => {
+  const m = makeMocks({ prAuthor: 'outside-helper', isCollaborator: true });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'allow');
+  assert.equal(m.outputs.reason, 'collaborator');
+});
+
+test('evaluate: org member → allow org_member', async () => {
+  const m = makeMocks({ prAuthor: 'circle-employee', isOrgMember: true });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'allow');
+  assert.equal(m.outputs.reason, 'org_member');
+});
+
+test('evaluate: vouched user → allow vouched', async () => {
+  const m = makeMocks({
+    prAuthor: 'trusted-contrib',
+    files: { '.github/VOUCHED': 'trusted-contrib' },
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'allow');
+  assert.equal(m.outputs.reason, 'vouched');
+});
+
+test('evaluate: no issue ref in body → close no_issue_reference', async () => {
+  const m = makeMocks({ prAuthor: 'someone', prBody: 'just a PR' });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'close');
+  assert.equal(m.outputs.reason, 'no_issue_reference');
+});
+
+test('evaluate: issue fetch fails → close issue_not_found', async () => {
+  const m = makeMocks({
+    prAuthor: 'someone',
+    prBody: 'Closes: #42',
+    issueData: null, // makeMocks throws 404 when null
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'close');
+  assert.equal(m.outputs.reason, 'issue_not_found');
+  assert.equal(m.outputs.issue_number, '42');
+});
+
+test('evaluate: PR author assigned to referenced issue → allow assigned', async () => {
+  const m = makeMocks({
+    prAuthor: 'someone',
+    prBody: 'Closes #42',
+    issueData: { assignees: [{ login: 'someone' }] },
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'allow');
+  assert.equal(m.outputs.reason, 'assigned');
+  assert.equal(m.outputs.issue_number, '42');
+});
+
+test('evaluate: codeowner /assign-tagged → allow tagged_by_codeowner', async () => {
+  const m = makeMocks({
+    prAuthor: 'newcontrib',
+    prBody: 'Fixes: #42',
+    files: { '.github/CODEOWNERS': '* @maintainer' },
+    issueData: { assignees: [] },
+    comments: [
+      { user: { login: 'maintainer' }, body: '/assign @newcontrib', html_url: 'x' },
+    ],
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'allow');
+  assert.equal(m.outputs.reason, 'tagged_by_codeowner');
+});
+
+test('evaluate: no trust signal at all → close not_assigned_to_issue', async () => {
+  const m = makeMocks({
+    prAuthor: 'random',
+    prBody: 'closes #42',
+    files: { '.github/CODEOWNERS': '* @maintainer' },
+    issueData: { assignees: [{ login: 'someone-else' }] },
+    comments: [],
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'close');
+  assert.equal(m.outputs.reason, 'not_assigned_to_issue');
+  assert.equal(m.outputs.issue_number, '42');
+});
+
+test('evaluate: username matching is case-insensitive', async () => {
+  // PR author is `Alice` but VOUCHED has `alice` lowercase.
+  const m = makeMocks({
+    prAuthor: 'Alice',
+    files: { '.github/VOUCHED': 'alice' },
+  });
+  await evaluate(m);
+  assert.equal(m.outputs.status, 'allow');
+  assert.equal(m.outputs.reason, 'vouched');
+});

--- a/.github/workflows/pr-gate-scripts.yml
+++ b/.github/workflows/pr-gate-scripts.yml
@@ -1,0 +1,32 @@
+name: PR Gate Scripts
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/pr-gate/**'
+      - '.github/workflows/pr-gate.yml'
+      - '.github/workflows/pr-gate-scripts.yml'
+  push:
+    branches: main
+    paths:
+      - '.github/scripts/pr-gate/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test pr-gate scripts
+    runs-on: github-hosted-small
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        with:
+          node-version: '20'
+      - name: Run tests
+        working-directory: .github/scripts/pr-gate
+        run: node --test

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -157,6 +157,50 @@ jobs:
               core.setOutput('is_org_member', 'false');
             }
 
+      - name: Check if author is vouched
+        id: check-vouched
+        if: |
+          steps.check-denounced.outputs.is_denounced == 'false' &&
+          steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
+          steps.check-codeowner.outputs.is_codeowner == 'false' &&
+          steps.check-collaborator.outputs.is_collaborator == 'false' &&
+          steps.check-org-member.outputs.is_org_member == 'false'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+
+            let content;
+            try {
+              const response = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: '.github/VOUCHED',
+                ref: context.payload.pull_request.base.ref,
+              });
+              content = Buffer.from(response.data.content, 'base64').toString('utf-8');
+            } catch (error) {
+              console.log(`No VOUCHED file found: ${error.message}`);
+              core.setOutput('is_vouched', 'false');
+              return;
+            }
+
+            const prAuthorLower = prAuthor.toLowerCase();
+            for (const rawLine of content.split('\n')) {
+              const line = rawLine.trim();
+              if (!line || line.startsWith('#')) continue;
+              const colonIdx = line.indexOf(':');
+              const name = (colonIdx === -1 ? line : line.slice(0, colonIdx)).trim().toLowerCase();
+              if (name === prAuthorLower) {
+                console.log(`${prAuthor} is vouched`);
+                core.setOutput('is_vouched', 'true');
+                return;
+              }
+            }
+
+            console.log(`${prAuthor} is not vouched`);
+            core.setOutput('is_vouched', 'false');
+
       - name: Check issue assignment
         id: check-assignment
         if: |
@@ -164,7 +208,8 @@ jobs:
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
           steps.check-collaborator.outputs.is_collaborator == 'false' &&
-          steps.check-org-member.outputs.is_org_member == 'false'
+          steps.check-org-member.outputs.is_org_member == 'false' &&
+          steps.check-vouched.outputs.is_vouched == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
@@ -220,6 +265,7 @@ jobs:
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
           steps.check-collaborator.outputs.is_collaborator == 'false' &&
           steps.check-org-member.outputs.is_org_member == 'false' &&
+          steps.check-vouched.outputs.is_vouched == 'false' &&
           steps.check-assignment.outputs.is_assigned == 'false' &&
           steps.check-assignment.outputs.reason == 'not_assigned_to_issue'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
@@ -293,6 +339,7 @@ jobs:
             steps.check-codeowner.outputs.is_codeowner == 'false' &&
             steps.check-collaborator.outputs.is_collaborator == 'false' &&
             steps.check-org-member.outputs.is_org_member == 'false' &&
+            steps.check-vouched.outputs.is_vouched == 'false' &&
             steps.check-assignment.outputs.is_assigned == 'false' &&
             steps.check-tagged-by-codeowner.outputs.is_tagged_by_codeowner != 'true'
           )

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -14,221 +14,42 @@ jobs:
     name: Check eligibility
     runs-on: github-hosted-small
     steps:
+      # actions/checkout defaults to the base ref under pull_request_target,
+      # so PR head code is never executed. We only need the base checkout to
+      # load the scripts below; trust-input files (DENOUNCED, VOUCHED, etc.)
+      # are still fetched via the REST API against base.ref for defense in
+      # depth.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          sparse-checkout: |
+            .github/scripts/pr-gate
+          sparse-checkout-cone-mode: false
+
       - name: Evaluate eligibility
         id: evaluate
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
-            const prAuthor = context.payload.pull_request.user.login;
-            const prAuthorLower = prAuthor.toLowerCase();
-            const prBody = context.payload.pull_request.body || '';
-            const { owner, repo } = context.repo;
-            const baseRef = context.payload.pull_request.base.ref;
-
-            async function readBaseFile(path) {
-              try {
-                const response = await github.rest.repos.getContent({ owner, repo, path, ref: baseRef });
-                return Buffer.from(response.data.content, 'base64').toString('utf-8');
-              } catch (error) {
-                console.log(`Could not read ${path} from ${baseRef}: ${error.message}`);
-                return null;
-              }
-            }
-
-            // Parse a one-username-per-line list with `#` comments and optional
-            // `: reason` suffix. Returns Map<usernameLower, reasonString>.
-            function parseList(content) {
-              const map = new Map();
-              if (!content) return map;
-              for (const rawLine of content.split('\n')) {
-                const line = rawLine.trim();
-                if (!line || line.startsWith('#')) continue;
-                const colonIdx = line.indexOf(':');
-                const name = (colonIdx === -1 ? line : line.slice(0, colonIdx)).trim().toLowerCase();
-                const reason = colonIdx === -1 ? '' : line.slice(colonIdx + 1).trim();
-                if (name) map.set(name, reason);
-              }
-              return map;
-            }
-
-            function decide(status, reason, extras = {}) {
-              console.log(`Decision: ${status} (${reason})`);
-              core.setOutput('status', status);
-              core.setOutput('reason', reason);
-              for (const [k, v] of Object.entries(extras)) {
-                core.setOutput(k, v);
-              }
-            }
-
-            // 1. Denounce list overrides everything else.
-            const denounced = parseList(await readBaseFile('.github/DENOUNCED'));
-            if (denounced.has(prAuthorLower)) {
-              return decide('close', 'denounced', { denounce_reason: denounced.get(prAuthorLower) });
-            }
-
-            // 2. Allowed bots.
-            if (prAuthor === 'dependabot[bot]' || prAuthor === 'stepsecurity-app[bot]') {
-              return decide('allow', 'bot');
-            }
-
-            // 3. Codeowner — parse CODEOWNERS but skip @org/team handles
-            //    (negative lookahead) so they aren't truncated to just @org.
-            const codeownersFile = (await readBaseFile('.github/CODEOWNERS')) || '';
-            const codeowners = (codeownersFile.match(/@[\w-]+(?!\/)\b/g) || [])
-              .map(c => c.substring(1).toLowerCase());
-            if (codeowners.includes(prAuthorLower)) {
-              return decide('allow', 'codeowner');
-            }
-
-            // 4. Repo collaborator (any access level: read/triage/write/admin).
-            try {
-              await github.rest.repos.checkCollaborator({ owner, repo, username: prAuthor });
-              return decide('allow', 'collaborator');
-            } catch (error) {
-              console.log(`${prAuthor} is not a collaborator: ${error.status}`);
-            }
-
-            // 5. Org member.
-            const org = 'circlefin';
-            try {
-              await github.rest.orgs.checkMembershipForUser({ org, username: prAuthor });
-              return decide('allow', 'org_member');
-            } catch (error) {
-              console.log(`${prAuthor} is not a member of ${org}: ${error.status}`);
-            }
-
-            // 6. Vouched list.
-            const vouched = parseList(await readBaseFile('.github/VOUCHED'));
-            if (vouched.has(prAuthorLower)) {
-              return decide('allow', 'vouched');
-            }
-
-            // 7. Issue reference + assignment.
-            const issuePrefixes = ['closes', 'fixes', 'fix', 'close', 'resolve', 'resolves'];
-            const issueRefRegex = new RegExp(`(?:${issuePrefixes.join('|')}):?\\s*#(\\d+)`, 'i');
-            const issueMatch = prBody.match(issueRefRegex);
-            if (!issueMatch) {
-              return decide('close', 'no_issue_reference');
-            }
-            const issueNumber = parseInt(issueMatch[1], 10);
-
-            let issue;
-            try {
-              issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
-            } catch (error) {
-              console.log(`Could not fetch issue #${issueNumber}: ${error.message}`);
-              return decide('close', 'issue_not_found', { issue_number: String(issueNumber) });
-            }
-
-            const assignees = issue.data.assignees.map(a => a.login.toLowerCase());
-            if (assignees.includes(prAuthorLower)) {
-              return decide('allow', 'assigned', { issue_number: String(issueNumber) });
-            }
-
-            // 8. /assign @user from any codeowner — union across all codeowner
-            //    comments and across all /assign occurrences within each
-            //    comment, so A's /assign @alice doesn't invalidate B's earlier
-            //    /assign @bob and `/assign @alice @bob` names both.
-            if (codeowners.length > 0) {
-              try {
-                const comments = await github.paginate(github.rest.issues.listComments, {
-                  owner, repo, issue_number: issueNumber, per_page: 100,
-                });
-                const assignPattern = /\/assign((?:\s+@[\w-]+)+)/gi;
-                const userPattern = /@([\w-]+)/g;
-                const taggedSet = new Set();
-                for (const comment of comments) {
-                  if (!codeowners.includes(comment.user.login.toLowerCase())) continue;
-                  for (const assignMatch of comment.body.matchAll(assignPattern)) {
-                    for (const userMatch of assignMatch[1].matchAll(userPattern)) {
-                      taggedSet.add(userMatch[1].toLowerCase());
-                      console.log(`/assign @${userMatch[1]} from codeowner @${comment.user.login} (${comment.html_url})`);
-                    }
-                  }
-                }
-                if (taggedSet.has(prAuthorLower)) {
-                  return decide('allow', 'tagged_by_codeowner', { issue_number: String(issueNumber) });
-                }
-                console.log(`No /assign @${prAuthor} from any codeowner. Tagged set: ${[...taggedSet].join(', ') || '(none)'}`);
-              } catch (error) {
-                console.log(`Error fetching comments for issue #${issueNumber}: ${error.message}`);
-              }
-            }
-
-            return decide('close', 'not_assigned_to_issue', { issue_number: String(issueNumber) });
+            const { evaluate } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-gate/evaluate.js`);
+            await evaluate({ github, context, core });
 
       - name: Close ineligible PR
         if: steps.evaluate.outputs.status == 'close'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           DENOUNCE_REASON: ${{ steps.evaluate.outputs.denounce_reason }}
+          REJECTION_REASON: ${{ steps.evaluate.outputs.reason }}
+          ISSUE_NUMBER: ${{ steps.evaluate.outputs.issue_number }}
         with:
           script: |
-            const reason = '${{ steps.evaluate.outputs.reason }}';
-            const issueNumber = '${{ steps.evaluate.outputs.issue_number }}';
-            const prAuthor = context.payload.pull_request.user.login;
-            const denounceReason = process.env.DENOUNCE_REASON || '';
-
-            const knownTemplates = new Set([
-              'denounced',
-              'no_issue_reference',
-              'not_assigned_to_issue',
-              'issue_not_found',
-            ]);
-            const templateName = knownTemplates.has(reason) ? reason : 'default';
-
-            // Load the rejection message from the base ref — pull_request_target
-            // pins this to trusted content so a malicious PR can't substitute
-            // its own message.
-            let template;
-            try {
-              const response = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: `.github/pr-gate-messages/${templateName}.md`,
-                ref: context.payload.pull_request.base.ref,
-              });
-              template = Buffer.from(response.data.content, 'base64').toString('utf-8');
-            } catch (error) {
-              console.log(`Could not load template ${templateName}.md: ${error.message}`);
-              template = `Hi @{{prAuthor}}, this PR was closed because it does not meet our contribution requirements. See CONTRIBUTING.md.`;
-            }
-
-            const vars = {
-              prAuthor,
-              issueNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              reasonBlock: denounceReason ? ` Reason: ${denounceReason}.` : '',
-            };
-            const message = Object.entries(vars).reduce(
-              (acc, [k, v]) => acc.replaceAll(`{{${k}}}`, v),
-              template,
-            );
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: message,
+            const { close } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-gate/close.js`);
+            await close({
+              github,
+              context,
+              core,
+              inputs: {
+                reason: process.env.REJECTION_REASON || '',
+                issueNumber: process.env.ISSUE_NUMBER || '',
+                denounceReason: process.env.DENOUNCE_REASON || '',
+              },
             });
-
-            try {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                labels: ['need-triage'],
-              });
-            } catch (error) {
-              console.log('Could not add label (may not exist):', error.message);
-            }
-
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              state: 'closed',
-            });
-
-            console.log('PR closed successfully');

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -172,45 +172,40 @@ jobs:
 
               console.log(`Found ${comments.length} comments on issue #${issueNumber}`);
 
-              // Look for /assign @username commands in comments from codeowners
-              // We need to find the latest such command to determine current assignment
+              // Collect every user any codeowner has /assign'd anywhere in the
+              // thread. The union is what matters: codeowner A assigning
+              // @alice should not invalidate codeowner B's earlier /assign
+              // @bob, and `/assign @alice @bob` in one comment names both.
+              // Revocation isn't supported here — closing the PR is the
+              // intended escape hatch.
               const prAuthorLower = prAuthor.toLowerCase();
-              const assignPattern = /\/assign\s+@([\w-]+)/gi;
+              const assignPattern = /\/assign((?:\s+@[\w-]+)+)/gi;
+              const userPattern = /@([\w-]+)/g;
+              const assignedUsers = new Set();
 
-              // Process comments in reverse order (newest first) to find the latest assignment
-              for (let i = comments.length - 1; i >= 0; i--) {
-                const comment = comments[i];
+              for (const comment of comments) {
                 const commentAuthor = comment.user.login.toLowerCase();
-
-                // Only consider comments from codeowners
                 if (!codeownerUsernames.includes(commentAuthor)) {
                   continue;
                 }
 
-                // Find all /assign commands in this comment
-                const matches = [...comment.body.matchAll(assignPattern)];
-                if (matches.length > 0) {
-                  // Get the last /assign command in this comment
-                  const lastMatch = matches[matches.length - 1];
-                  const assignedUser = lastMatch[1].toLowerCase();
-
-                  console.log(`Found /assign @${lastMatch[1]} in comment by codeowner @${comment.user.login}`);
-                  console.log(`Comment URL: ${comment.html_url}`);
-
-                  if (assignedUser === prAuthorLower) {
-                    console.log(`PR author @${prAuthor} was assigned by codeowner`);
-                    core.setOutput('is_tagged_by_codeowner', 'true');
-                    return;
-                  } else {
-                    console.log(`Latest /assign command is for @${lastMatch[1]}, not @${prAuthor}`);
-                    core.setOutput('is_tagged_by_codeowner', 'false');
-                    return;
+                for (const assignMatch of comment.body.matchAll(assignPattern)) {
+                  for (const userMatch of assignMatch[1].matchAll(userPattern)) {
+                    const assignedUser = userMatch[1].toLowerCase();
+                    assignedUsers.add(assignedUser);
+                    console.log(`/assign @${userMatch[1]} from codeowner @${comment.user.login} (${comment.html_url})`);
                   }
                 }
               }
 
-              console.log(`No /assign command from codeowner found for @${prAuthor}`);
-              core.setOutput('is_tagged_by_codeowner', 'false');
+              if (assignedUsers.has(prAuthorLower)) {
+                console.log(`PR author @${prAuthor} was /assign'd by a codeowner`);
+                core.setOutput('is_tagged_by_codeowner', 'true');
+              } else {
+                const assignedList = [...assignedUsers].join(', ') || '(none)';
+                console.log(`No /assign @${prAuthor} from any codeowner. Assigned set: ${assignedList}`);
+                core.setOutput('is_tagged_by_codeowner', 'false');
+              }
             } catch (error) {
               console.log(`Error fetching comments for issue #${issueNumber}: ${error.message}`);
               core.setOutput('is_tagged_by_codeowner', 'false');

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -41,8 +41,9 @@ jobs:
               });
 
               const content = Buffer.from(response.data.content, 'base64').toString('utf-8');
-              // Extract usernames from CODEOWNERS (matches @username patterns)
-              const codeowners = content.match(/@[\w-]+/g) || [];
+              // Match individual @username handles only; skip team handles (@org/team)
+              // via negative lookahead so they don't get truncated to just @org.
+              const codeowners = content.match(/@[\w-]+(?!\/)\b/g) || [];
               const codeownerUsernames = codeowners.map(c => c.substring(1).toLowerCase());
 
               core.setOutput('codeowner_list', JSON.stringify(codeownerUsernames));

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -4,6 +4,11 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   check-eligibility:
     name: Check eligibility

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -225,56 +225,41 @@ jobs:
             const issueNumber = '${{ steps.check-assignment.outputs.issue_number }}';
             const prAuthor = context.payload.pull_request.user.login;
 
-            let message = '';
+            const knownReasons = new Set([
+              'no_issue_reference',
+              'not_assigned_to_issue',
+              'issue_not_found',
+            ]);
+            const templateName = knownReasons.has(reason) ? reason : 'default';
 
-            if (reason === 'no_issue_reference') {
-              message = `Hi @${prAuthor},
-
-            Thank you for your interest in contributing to Malachite.
-
-            This PR has been automatically closed because it does not reference a GitHub issue. All PRs must reference an existing issue using the format \`Closes: #XXX\`.
-
-            **To contribute properly:**
-            1. Find an existing issue you'd like to work on, or [open a new issue](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new) describing your proposed change
-            2. Comment on the issue requesting assignment and wait for maintainer approval
-            3. Only submit a PR after you have been assigned to the issue
-
-            Please see our [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) for more details.`;
-            } else if (reason === 'not_assigned_to_issue') {
-              message = `Hi @${prAuthor},
-
-            Thank you for your interest in contributing to Malachite.
-
-            This PR has been automatically closed because you are not assigned to issue #${issueNumber}. We require contributors to be explicitly assigned to an issue before submitting a PR.
-
-            **To contribute properly:**
-            1. Comment on issue #${issueNumber} requesting assignment
-            2. Wait for maintainer approval
-            3. Only submit a PR after you have been assigned
-
-            Please see our [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) for more details.`;
-            } else if (reason === 'issue_not_found') {
-              message = `Hi @${prAuthor},
-
-            Thank you for your interest in contributing to Malachite.
-
-            This PR has been automatically closed because the referenced issue could not be found. Please ensure you reference a valid, existing issue using the format \`Closes: #XXX\`.
-
-            **To contribute properly:**
-            1. Find an existing issue you'd like to work on, or [open a new issue](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new) describing your proposed change
-            2. Comment on the issue requesting assignment and wait for maintainer approval
-            3. Only submit a PR after you have been assigned to the issue
-
-            Please see our [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) for more details.`;
-            } else {
-              message = `Hi @${prAuthor},
-
-            Thank you for your interest in contributing to Malachite.
-
-            This PR has been automatically closed because it does not meet our contribution requirements.
-
-            Please see our [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) for details on how to contribute properly.`;
+            // Load the rejection message from the base ref — pull_request_target
+            // runs against the merge base, but reading template content via the
+            // contents API explicitly pins us to the trusted base so a malicious
+            // PR can't substitute its own message.
+            let template;
+            try {
+              const response = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: `.github/pr-gate-messages/${templateName}.md`,
+                ref: context.payload.pull_request.base.ref,
+              });
+              template = Buffer.from(response.data.content, 'base64').toString('utf-8');
+            } catch (error) {
+              console.log(`Could not load template ${templateName}.md: ${error.message}`);
+              template = `Hi @{{prAuthor}}, this PR was closed because it does not meet our contribution requirements. See CONTRIBUTING.md.`;
             }
+
+            const vars = {
+              prAuthor,
+              issueNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            };
+            const message = Object.entries(vars).reduce(
+              (acc, [k, v]) => acc.replaceAll(`{{${k}}}`, v),
+              template,
+            );
 
             // Add comment
             await github.rest.issues.createComment({

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -60,11 +60,37 @@ jobs:
               core.setOutput('is_codeowner', 'false');
             }
 
+      - name: Check if author is repo collaborator
+        id: check-collaborator
+        if: |
+          steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
+          steps.check-codeowner.outputs.is_codeowner == 'false'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+
+            try {
+              await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: prAuthor,
+              });
+              // 204 = any access level (read/triage/write/admin). Catches outside
+              // collaborators who aren't necessarily org members.
+              console.log(`${prAuthor} is a collaborator on ${context.repo.owner}/${context.repo.repo}`);
+              core.setOutput('is_collaborator', 'true');
+            } catch (error) {
+              console.log(`${prAuthor} is NOT a collaborator: ${error.status}`);
+              core.setOutput('is_collaborator', 'false');
+            }
+
       - name: Check if author is org member
         id: check-org-member
         if: |
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
-          steps.check-codeowner.outputs.is_codeowner == 'false'
+          steps.check-codeowner.outputs.is_codeowner == 'false' &&
+          steps.check-collaborator.outputs.is_collaborator == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
@@ -91,6 +117,7 @@ jobs:
         if: |
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
+          steps.check-collaborator.outputs.is_collaborator == 'false' &&
           steps.check-org-member.outputs.is_org_member == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -144,6 +171,7 @@ jobs:
         if: |
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
+          steps.check-collaborator.outputs.is_collaborator == 'false' &&
           steps.check-org-member.outputs.is_org_member == 'false' &&
           steps.check-assignment.outputs.is_assigned == 'false' &&
           steps.check-assignment.outputs.reason == 'not_assigned_to_issue'
@@ -215,6 +243,7 @@ jobs:
         if: |
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
+          steps.check-collaborator.outputs.is_collaborator == 'false' &&
           steps.check-org-member.outputs.is_org_member == 'false' &&
           steps.check-assignment.outputs.is_assigned == 'false' &&
           steps.check-tagged-by-codeowner.outputs.is_tagged_by_codeowner != 'true'

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -14,362 +14,172 @@ jobs:
     name: Check eligibility
     runs-on: github-hosted-small
     steps:
-      - name: Check if author is denounced
-        id: check-denounced
+      - name: Evaluate eligibility
+        id: evaluate
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
-
-            let content;
-            try {
-              const response = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: '.github/DENOUNCED',
-                ref: context.payload.pull_request.base.ref,
-              });
-              content = Buffer.from(response.data.content, 'base64').toString('utf-8');
-            } catch (error) {
-              console.log(`No DENOUNCED file found: ${error.message}`);
-              core.setOutput('is_denounced', 'false');
-              return;
-            }
-
             const prAuthorLower = prAuthor.toLowerCase();
-            for (const rawLine of content.split('\n')) {
-              const line = rawLine.trim();
-              if (!line || line.startsWith('#')) continue;
-              const colonIdx = line.indexOf(':');
-              const name = (colonIdx === -1 ? line : line.slice(0, colonIdx)).trim().toLowerCase();
-              const reason = colonIdx === -1 ? '' : line.slice(colonIdx + 1).trim();
-              if (name === prAuthorLower) {
-                console.log(`${prAuthor} is denounced${reason ? `: ${reason}` : ''}`);
-                core.setOutput('is_denounced', 'true');
-                core.setOutput('denounce_reason', reason);
-                return;
-              }
-            }
-
-            console.log(`${prAuthor} is not denounced`);
-            core.setOutput('is_denounced', 'false');
-
-      - name: Check if author is allowed bot
-        id: check-dependabot
-        if: steps.check-denounced.outputs.is_denounced == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          script: |
-            const prAuthor = context.payload.pull_request.user.login;
-            const isAllowed = prAuthor === 'dependabot[bot]' || prAuthor === 'stepsecurity-app[bot]';
-            console.log(`PR author: ${prAuthor}, is allowed bot: ${isAllowed}`);
-            core.setOutput('is_allowed_bot', isAllowed ? 'true' : 'false');
-
-      - name: Check if author is codeowner
-        id: check-codeowner
-        if: |
-          steps.check-denounced.outputs.is_denounced == 'false' &&
-          steps.check-dependabot.outputs.is_allowed_bot == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          script: |
-            const prAuthor = context.payload.pull_request.user.login;
-
-            try {
-              const response = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: '.github/CODEOWNERS',
-                ref: context.payload.pull_request.base.ref
-              });
-
-              const content = Buffer.from(response.data.content, 'base64').toString('utf-8');
-              // Match individual @username handles only; skip team handles (@org/team)
-              // via negative lookahead so they don't get truncated to just @org.
-              const codeowners = content.match(/@[\w-]+(?!\/)\b/g) || [];
-              const codeownerUsernames = codeowners.map(c => c.substring(1).toLowerCase());
-
-              core.setOutput('codeowner_list', JSON.stringify(codeownerUsernames));
-
-              if (codeownerUsernames.includes(prAuthor.toLowerCase())) {
-                console.log(`${prAuthor} is a codeowner`);
-                core.setOutput('is_codeowner', 'true');
-              } else {
-                console.log(`${prAuthor} is NOT a codeowner`);
-                core.setOutput('is_codeowner', 'false');
-              }
-            } catch (error) {
-              console.log(`Could not read CODEOWNERS file: ${error.message}`);
-              core.setOutput('is_codeowner', 'false');
-            }
-
-      - name: Check if author is repo collaborator
-        id: check-collaborator
-        if: |
-          steps.check-denounced.outputs.is_denounced == 'false' &&
-          steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
-          steps.check-codeowner.outputs.is_codeowner == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          script: |
-            const prAuthor = context.payload.pull_request.user.login;
-
-            try {
-              await github.rest.repos.checkCollaborator({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                username: prAuthor,
-              });
-              // 204 = any access level (read/triage/write/admin). Catches outside
-              // collaborators who aren't necessarily org members.
-              console.log(`${prAuthor} is a collaborator on ${context.repo.owner}/${context.repo.repo}`);
-              core.setOutput('is_collaborator', 'true');
-            } catch (error) {
-              console.log(`${prAuthor} is NOT a collaborator: ${error.status}`);
-              core.setOutput('is_collaborator', 'false');
-            }
-
-      - name: Check if author is org member
-        id: check-org-member
-        if: |
-          steps.check-denounced.outputs.is_denounced == 'false' &&
-          steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
-          steps.check-codeowner.outputs.is_codeowner == 'false' &&
-          steps.check-collaborator.outputs.is_collaborator == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          script: |
-            const prAuthor = context.payload.pull_request.user.login;
-            const org = 'circlefin';
-
-            try {
-              const response = await github.rest.orgs.checkMembershipForUser({
-                org: org,
-                username: prAuthor
-              });
-              // Status 204 means the user is a member
-              console.log(`${prAuthor} is a member of ${org}`);
-              core.setOutput('is_org_member', 'true');
-            } catch (error) {
-              // Status 404 means the user is not a member (or org doesn't exist)
-              // Status 302 means the requester is not an org member (redirect to login)
-              console.log(`${prAuthor} is NOT a member of ${org}: ${error.status}`);
-              core.setOutput('is_org_member', 'false');
-            }
-
-      - name: Check if author is vouched
-        id: check-vouched
-        if: |
-          steps.check-denounced.outputs.is_denounced == 'false' &&
-          steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
-          steps.check-codeowner.outputs.is_codeowner == 'false' &&
-          steps.check-collaborator.outputs.is_collaborator == 'false' &&
-          steps.check-org-member.outputs.is_org_member == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          script: |
-            const prAuthor = context.payload.pull_request.user.login;
-
-            let content;
-            try {
-              const response = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: '.github/VOUCHED',
-                ref: context.payload.pull_request.base.ref,
-              });
-              content = Buffer.from(response.data.content, 'base64').toString('utf-8');
-            } catch (error) {
-              console.log(`No VOUCHED file found: ${error.message}`);
-              core.setOutput('is_vouched', 'false');
-              return;
-            }
-
-            const prAuthorLower = prAuthor.toLowerCase();
-            for (const rawLine of content.split('\n')) {
-              const line = rawLine.trim();
-              if (!line || line.startsWith('#')) continue;
-              const colonIdx = line.indexOf(':');
-              const name = (colonIdx === -1 ? line : line.slice(0, colonIdx)).trim().toLowerCase();
-              if (name === prAuthorLower) {
-                console.log(`${prAuthor} is vouched`);
-                core.setOutput('is_vouched', 'true');
-                return;
-              }
-            }
-
-            console.log(`${prAuthor} is not vouched`);
-            core.setOutput('is_vouched', 'false');
-
-      - name: Check issue assignment
-        id: check-assignment
-        if: |
-          steps.check-denounced.outputs.is_denounced == 'false' &&
-          steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
-          steps.check-codeowner.outputs.is_codeowner == 'false' &&
-          steps.check-collaborator.outputs.is_collaborator == 'false' &&
-          steps.check-org-member.outputs.is_org_member == 'false' &&
-          steps.check-vouched.outputs.is_vouched == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          script: |
             const prBody = context.payload.pull_request.body || '';
-            const prAuthor = context.payload.pull_request.user.login;
+            const { owner, repo } = context.repo;
+            const baseRef = context.payload.pull_request.base.ref;
 
-            // Extract issue number from PR body
-            const issuePrefixes = ['closes', 'fixes', 'fix', 'close', 'resolve', 'resolves'];
-            const prefixPattern = issuePrefixes.join('|');
-            const issueMatch = prBody.match(new RegExp(`(?:${prefixPattern}):?\\s*#(\\d+)`, 'i'));
-
-            if (!issueMatch) {
-              console.log('No issue reference found in PR body');
-              core.setOutput('is_assigned', 'false');
-              core.setOutput('reason', 'no_issue_reference');
-              return;
-            }
-
-            const issueNumber = parseInt(issueMatch[1], 10);
-            console.log(`Found issue reference: #${issueNumber}`);
-
-            try {
-              const issue = await github.rest.issues.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber
-              });
-
-              // Check if PR author is assigned to the issue
-              const assignees = issue.data.assignees.map(a => a.login);
-              console.log(`Issue assignees: ${assignees.join(', ')}`);
-
-              if (assignees.includes(prAuthor)) {
-                console.log(`PR author ${prAuthor} is assigned to issue #${issueNumber}`);
-                core.setOutput('is_assigned', 'true');
-              } else {
-                console.log(`PR author ${prAuthor} is NOT assigned to issue #${issueNumber}`);
-                core.setOutput('is_assigned', 'false');
-                core.setOutput('reason', 'not_assigned_to_issue');
-                core.setOutput('issue_number', issueNumber.toString());
+            async function readBaseFile(path) {
+              try {
+                const response = await github.rest.repos.getContent({ owner, repo, path, ref: baseRef });
+                return Buffer.from(response.data.content, 'base64').toString('utf-8');
+              } catch (error) {
+                console.log(`Could not read ${path} from ${baseRef}: ${error.message}`);
+                return null;
               }
-            } catch (error) {
-              console.log(`Error fetching issue #${issueNumber}: ${error.message}`);
-              core.setOutput('is_assigned', 'false');
-              core.setOutput('reason', 'issue_not_found');
             }
 
-      - name: Check if author is tagged by codeowner
-        id: check-tagged-by-codeowner
-        if: |
-          steps.check-denounced.outputs.is_denounced == 'false' &&
-          steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
-          steps.check-codeowner.outputs.is_codeowner == 'false' &&
-          steps.check-collaborator.outputs.is_collaborator == 'false' &&
-          steps.check-org-member.outputs.is_org_member == 'false' &&
-          steps.check-vouched.outputs.is_vouched == 'false' &&
-          steps.check-assignment.outputs.is_assigned == 'false' &&
-          steps.check-assignment.outputs.reason == 'not_assigned_to_issue'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          script: |
-            const prAuthor = context.payload.pull_request.user.login;
-            const issueNumber = parseInt('${{ steps.check-assignment.outputs.issue_number }}', 10);
-
-            const codeownerUsernames = JSON.parse('${{ steps.check-codeowner.outputs.codeowner_list }}' || '[]');
-
-            if (codeownerUsernames.length === 0) {
-              console.log('No codeowners found');
-              core.setOutput('is_tagged_by_codeowner', 'false');
-              return;
+            // Parse a one-username-per-line list with `#` comments and optional
+            // `: reason` suffix. Returns Map<usernameLower, reasonString>.
+            function parseList(content) {
+              const map = new Map();
+              if (!content) return map;
+              for (const rawLine of content.split('\n')) {
+                const line = rawLine.trim();
+                if (!line || line.startsWith('#')) continue;
+                const colonIdx = line.indexOf(':');
+                const name = (colonIdx === -1 ? line : line.slice(0, colonIdx)).trim().toLowerCase();
+                const reason = colonIdx === -1 ? '' : line.slice(colonIdx + 1).trim();
+                if (name) map.set(name, reason);
+              }
+              return map;
             }
 
-            // Get all comments on the issue
+            function decide(status, reason, extras = {}) {
+              console.log(`Decision: ${status} (${reason})`);
+              core.setOutput('status', status);
+              core.setOutput('reason', reason);
+              for (const [k, v] of Object.entries(extras)) {
+                core.setOutput(k, v);
+              }
+            }
+
+            // 1. Denounce list overrides everything else.
+            const denounced = parseList(await readBaseFile('.github/DENOUNCED'));
+            if (denounced.has(prAuthorLower)) {
+              return decide('close', 'denounced', { denounce_reason: denounced.get(prAuthorLower) });
+            }
+
+            // 2. Allowed bots.
+            if (prAuthor === 'dependabot[bot]' || prAuthor === 'stepsecurity-app[bot]') {
+              return decide('allow', 'bot');
+            }
+
+            // 3. Codeowner — parse CODEOWNERS but skip @org/team handles
+            //    (negative lookahead) so they aren't truncated to just @org.
+            const codeownersFile = (await readBaseFile('.github/CODEOWNERS')) || '';
+            const codeowners = (codeownersFile.match(/@[\w-]+(?!\/)\b/g) || [])
+              .map(c => c.substring(1).toLowerCase());
+            if (codeowners.includes(prAuthorLower)) {
+              return decide('allow', 'codeowner');
+            }
+
+            // 4. Repo collaborator (any access level: read/triage/write/admin).
             try {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100
-              });
+              await github.rest.repos.checkCollaborator({ owner, repo, username: prAuthor });
+              return decide('allow', 'collaborator');
+            } catch (error) {
+              console.log(`${prAuthor} is not a collaborator: ${error.status}`);
+            }
 
-              console.log(`Found ${comments.length} comments on issue #${issueNumber}`);
+            // 5. Org member.
+            const org = 'circlefin';
+            try {
+              await github.rest.orgs.checkMembershipForUser({ org, username: prAuthor });
+              return decide('allow', 'org_member');
+            } catch (error) {
+              console.log(`${prAuthor} is not a member of ${org}: ${error.status}`);
+            }
 
-              // Collect every user any codeowner has /assign'd anywhere in the
-              // thread. The union is what matters: codeowner A assigning
-              // @alice should not invalidate codeowner B's earlier /assign
-              // @bob, and `/assign @alice @bob` in one comment names both.
-              // Revocation isn't supported here — closing the PR is the
-              // intended escape hatch.
-              const prAuthorLower = prAuthor.toLowerCase();
-              const assignPattern = /\/assign((?:\s+@[\w-]+)+)/gi;
-              const userPattern = /@([\w-]+)/g;
-              const assignedUsers = new Set();
+            // 6. Vouched list.
+            const vouched = parseList(await readBaseFile('.github/VOUCHED'));
+            if (vouched.has(prAuthorLower)) {
+              return decide('allow', 'vouched');
+            }
 
-              for (const comment of comments) {
-                const commentAuthor = comment.user.login.toLowerCase();
-                if (!codeownerUsernames.includes(commentAuthor)) {
-                  continue;
-                }
+            // 7. Issue reference + assignment.
+            const issuePrefixes = ['closes', 'fixes', 'fix', 'close', 'resolve', 'resolves'];
+            const issueRefRegex = new RegExp(`(?:${issuePrefixes.join('|')}):?\\s*#(\\d+)`, 'i');
+            const issueMatch = prBody.match(issueRefRegex);
+            if (!issueMatch) {
+              return decide('close', 'no_issue_reference');
+            }
+            const issueNumber = parseInt(issueMatch[1], 10);
 
-                for (const assignMatch of comment.body.matchAll(assignPattern)) {
-                  for (const userMatch of assignMatch[1].matchAll(userPattern)) {
-                    const assignedUser = userMatch[1].toLowerCase();
-                    assignedUsers.add(assignedUser);
-                    console.log(`/assign @${userMatch[1]} from codeowner @${comment.user.login} (${comment.html_url})`);
+            let issue;
+            try {
+              issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+            } catch (error) {
+              console.log(`Could not fetch issue #${issueNumber}: ${error.message}`);
+              return decide('close', 'issue_not_found', { issue_number: String(issueNumber) });
+            }
+
+            const assignees = issue.data.assignees.map(a => a.login.toLowerCase());
+            if (assignees.includes(prAuthorLower)) {
+              return decide('allow', 'assigned', { issue_number: String(issueNumber) });
+            }
+
+            // 8. /assign @user from any codeowner — union across all codeowner
+            //    comments and across all /assign occurrences within each
+            //    comment, so A's /assign @alice doesn't invalidate B's earlier
+            //    /assign @bob and `/assign @alice @bob` names both.
+            if (codeowners.length > 0) {
+              try {
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner, repo, issue_number: issueNumber, per_page: 100,
+                });
+                const assignPattern = /\/assign((?:\s+@[\w-]+)+)/gi;
+                const userPattern = /@([\w-]+)/g;
+                const taggedSet = new Set();
+                for (const comment of comments) {
+                  if (!codeowners.includes(comment.user.login.toLowerCase())) continue;
+                  for (const assignMatch of comment.body.matchAll(assignPattern)) {
+                    for (const userMatch of assignMatch[1].matchAll(userPattern)) {
+                      taggedSet.add(userMatch[1].toLowerCase());
+                      console.log(`/assign @${userMatch[1]} from codeowner @${comment.user.login} (${comment.html_url})`);
+                    }
                   }
                 }
+                if (taggedSet.has(prAuthorLower)) {
+                  return decide('allow', 'tagged_by_codeowner', { issue_number: String(issueNumber) });
+                }
+                console.log(`No /assign @${prAuthor} from any codeowner. Tagged set: ${[...taggedSet].join(', ') || '(none)'}`);
+              } catch (error) {
+                console.log(`Error fetching comments for issue #${issueNumber}: ${error.message}`);
               }
-
-              if (assignedUsers.has(prAuthorLower)) {
-                console.log(`PR author @${prAuthor} was /assign'd by a codeowner`);
-                core.setOutput('is_tagged_by_codeowner', 'true');
-              } else {
-                const assignedList = [...assignedUsers].join(', ') || '(none)';
-                console.log(`No /assign @${prAuthor} from any codeowner. Assigned set: ${assignedList}`);
-                core.setOutput('is_tagged_by_codeowner', 'false');
-              }
-            } catch (error) {
-              console.log(`Error fetching comments for issue #${issueNumber}: ${error.message}`);
-              core.setOutput('is_tagged_by_codeowner', 'false');
             }
 
+            return decide('close', 'not_assigned_to_issue', { issue_number: String(issueNumber) });
+
       - name: Close ineligible PR
-        if: |
-          steps.check-denounced.outputs.is_denounced == 'true' || (
-            steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
-            steps.check-codeowner.outputs.is_codeowner == 'false' &&
-            steps.check-collaborator.outputs.is_collaborator == 'false' &&
-            steps.check-org-member.outputs.is_org_member == 'false' &&
-            steps.check-vouched.outputs.is_vouched == 'false' &&
-            steps.check-assignment.outputs.is_assigned == 'false' &&
-            steps.check-tagged-by-codeowner.outputs.is_tagged_by_codeowner != 'true'
-          )
+        if: steps.evaluate.outputs.status == 'close'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
-          DENOUNCE_REASON: ${{ steps.check-denounced.outputs.denounce_reason }}
+          DENOUNCE_REASON: ${{ steps.evaluate.outputs.denounce_reason }}
         with:
           script: |
-            const isDenounced = '${{ steps.check-denounced.outputs.is_denounced }}' === 'true';
-            const reason = '${{ steps.check-assignment.outputs.reason }}';
-            const issueNumber = '${{ steps.check-assignment.outputs.issue_number }}';
+            const reason = '${{ steps.evaluate.outputs.reason }}';
+            const issueNumber = '${{ steps.evaluate.outputs.issue_number }}';
             const prAuthor = context.payload.pull_request.user.login;
             const denounceReason = process.env.DENOUNCE_REASON || '';
 
-            let templateName;
-            if (isDenounced) {
-              templateName = 'denounced';
-            } else {
-              const knownReasons = new Set([
-                'no_issue_reference',
-                'not_assigned_to_issue',
-                'issue_not_found',
-              ]);
-              templateName = knownReasons.has(reason) ? reason : 'default';
-            }
+            const knownTemplates = new Set([
+              'denounced',
+              'no_issue_reference',
+              'not_assigned_to_issue',
+              'issue_not_found',
+            ]);
+            const templateName = knownTemplates.has(reason) ? reason : 'default';
 
             // Load the rejection message from the base ref — pull_request_target
-            // runs against the merge base, but reading template content via the
-            // contents API explicitly pins us to the trusted base so a malicious
-            // PR can't substitute its own message.
+            // pins this to trusted content so a malicious PR can't substitute
+            // its own message.
             let template;
             try {
               const response = await github.rest.repos.getContent({
@@ -396,32 +206,29 @@ jobs:
               template,
             );
 
-            // Add comment
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: message
+              body: message,
             });
 
-            // Add label
             try {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                labels: ['need-triage']
+                labels: ['need-triage'],
               });
             } catch (error) {
               console.log('Could not add label (may not exist):', error.message);
             }
 
-            // Close PR
             await github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              state: 'closed'
+              state: 'closed',
             });
 
             console.log('PR closed successfully');

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -14,8 +14,49 @@ jobs:
     name: Check eligibility
     runs-on: github-hosted-small
     steps:
+      - name: Check if author is denounced
+        id: check-denounced
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+
+            let content;
+            try {
+              const response = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: '.github/DENOUNCED',
+                ref: context.payload.pull_request.base.ref,
+              });
+              content = Buffer.from(response.data.content, 'base64').toString('utf-8');
+            } catch (error) {
+              console.log(`No DENOUNCED file found: ${error.message}`);
+              core.setOutput('is_denounced', 'false');
+              return;
+            }
+
+            const prAuthorLower = prAuthor.toLowerCase();
+            for (const rawLine of content.split('\n')) {
+              const line = rawLine.trim();
+              if (!line || line.startsWith('#')) continue;
+              const colonIdx = line.indexOf(':');
+              const name = (colonIdx === -1 ? line : line.slice(0, colonIdx)).trim().toLowerCase();
+              const reason = colonIdx === -1 ? '' : line.slice(colonIdx + 1).trim();
+              if (name === prAuthorLower) {
+                console.log(`${prAuthor} is denounced${reason ? `: ${reason}` : ''}`);
+                core.setOutput('is_denounced', 'true');
+                core.setOutput('denounce_reason', reason);
+                return;
+              }
+            }
+
+            console.log(`${prAuthor} is not denounced`);
+            core.setOutput('is_denounced', 'false');
+
       - name: Check if author is allowed bot
         id: check-dependabot
+        if: steps.check-denounced.outputs.is_denounced == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
@@ -26,7 +67,9 @@ jobs:
 
       - name: Check if author is codeowner
         id: check-codeowner
-        if: steps.check-dependabot.outputs.is_allowed_bot == 'false'
+        if: |
+          steps.check-denounced.outputs.is_denounced == 'false' &&
+          steps.check-dependabot.outputs.is_allowed_bot == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
@@ -63,6 +106,7 @@ jobs:
       - name: Check if author is repo collaborator
         id: check-collaborator
         if: |
+          steps.check-denounced.outputs.is_denounced == 'false' &&
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
@@ -88,6 +132,7 @@ jobs:
       - name: Check if author is org member
         id: check-org-member
         if: |
+          steps.check-denounced.outputs.is_denounced == 'false' &&
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
           steps.check-collaborator.outputs.is_collaborator == 'false'
@@ -115,6 +160,7 @@ jobs:
       - name: Check issue assignment
         id: check-assignment
         if: |
+          steps.check-denounced.outputs.is_denounced == 'false' &&
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
           steps.check-collaborator.outputs.is_collaborator == 'false' &&
@@ -169,6 +215,7 @@ jobs:
       - name: Check if author is tagged by codeowner
         id: check-tagged-by-codeowner
         if: |
+          steps.check-denounced.outputs.is_denounced == 'false' &&
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
           steps.check-collaborator.outputs.is_collaborator == 'false' &&
@@ -241,25 +288,36 @@ jobs:
 
       - name: Close ineligible PR
         if: |
-          steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
-          steps.check-codeowner.outputs.is_codeowner == 'false' &&
-          steps.check-collaborator.outputs.is_collaborator == 'false' &&
-          steps.check-org-member.outputs.is_org_member == 'false' &&
-          steps.check-assignment.outputs.is_assigned == 'false' &&
-          steps.check-tagged-by-codeowner.outputs.is_tagged_by_codeowner != 'true'
+          steps.check-denounced.outputs.is_denounced == 'true' || (
+            steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
+            steps.check-codeowner.outputs.is_codeowner == 'false' &&
+            steps.check-collaborator.outputs.is_collaborator == 'false' &&
+            steps.check-org-member.outputs.is_org_member == 'false' &&
+            steps.check-assignment.outputs.is_assigned == 'false' &&
+            steps.check-tagged-by-codeowner.outputs.is_tagged_by_codeowner != 'true'
+          )
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          DENOUNCE_REASON: ${{ steps.check-denounced.outputs.denounce_reason }}
         with:
           script: |
+            const isDenounced = '${{ steps.check-denounced.outputs.is_denounced }}' === 'true';
             const reason = '${{ steps.check-assignment.outputs.reason }}';
             const issueNumber = '${{ steps.check-assignment.outputs.issue_number }}';
             const prAuthor = context.payload.pull_request.user.login;
+            const denounceReason = process.env.DENOUNCE_REASON || '';
 
-            const knownReasons = new Set([
-              'no_issue_reference',
-              'not_assigned_to_issue',
-              'issue_not_found',
-            ]);
-            const templateName = knownReasons.has(reason) ? reason : 'default';
+            let templateName;
+            if (isDenounced) {
+              templateName = 'denounced';
+            } else {
+              const knownReasons = new Set([
+                'no_issue_reference',
+                'not_assigned_to_issue',
+                'issue_not_found',
+              ]);
+              templateName = knownReasons.has(reason) ? reason : 'default';
+            }
 
             // Load the rejection message from the base ref — pull_request_target
             // runs against the merge base, but reading template content via the
@@ -284,6 +342,7 @@ jobs:
               issueNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
+              reasonBlock: denounceReason ? ` Reason: ${denounceReason}.` : '',
             };
             const message = Object.entries(vars).reduce(
               (acc, [k, v]) => acc.replaceAll(`{{${k}}}`, v),


### PR DESCRIPTION
Closes: #XXX

Reworks the PR Gate workflow that auto-closes external PRs lacking issue assignment. Preserves the existing contribution model (claim an issue, then PR) but fixes correctness bugs in the gate, borrows two ideas from [mitchellh/vouch](https://github.com/mitchellh/vouch), and extracts the inline workflow JavaScript into testable modules with CI coverage.

## Summary

**Bug fixes in existing checks**

- **CODEOWNERS team handles** were truncated by the `/@[\w-]+/g` regex — `@org/team` silently became `@org`, treating the org name as a codeowner username. Now skipped via negative lookahead until proper team expansion is needed.
- **`/assign` composition** returned on the first codeowner comment containing `/assign`, so codeowner A's later `/assign @alice` would invalidate codeowner B's earlier `/assign @bob`. And `/assign @alice @bob` in one comment only registered `@bob` (last match wins inside the comment). Now: union across every codeowner comment and every `/assign` occurrence.

**New capabilities (borrowed from vouch)**

- **`.github/DENOUNCED`** — flat file listing usernames whose PRs are auto-closed regardless of any other signal. First step in the ladder. Supports optional `: reason` that surfaces in the close comment.
- **`.github/VOUCHED`** — flat file of trusted external contributors who bypass the issue-assignment requirement. Complements (does not replace) the issue-claim flow.
- **Repo-collaborator bypass** — `repos.checkCollaborator` now runs before the org-membership check. Catches outside collaborators with explicit repo access (read/triage/write/admin) who aren't necessarily org members.

**Hardening / cleanup**

- Declared explicit workflow `permissions:` (contents: read, issues: write, pull-requests: write) so a future repo-wide default downgrade doesn't silently break the close step.
- Moved four inline rejection-message heredocs to `.github/pr-gate-messages/*.md` with `{{placeholder}}` substitution. Templates are still loaded from `base.ref` via the contents API for `pull_request_target` safety.
- Side effect of the template move: the previous messages embedded 12 spaces of indent in YAML/JS, which GitHub's markdown renderer treats as code blocks. New templates are left-aligned, so rejection comments are readable.
- Consolidated the eight-step `if:` ladder into one `Evaluate eligibility` script and one `Close ineligible PR` step gated by `steps.evaluate.outputs.status == 'close'`. Adding a future check is now one block in one script instead of inserting a step plus editing every subsequent step's condition.

**Extracted scripts + tests**

- Moved the two inline `actions/github-script` bodies into `.github/scripts/pr-gate/{evaluate,close}.js` as CommonJS modules. The workflow sparse-checks out only that directory and `require()`s each module. `actions/checkout` under `pull_request_target` defaults to the base ref, so the `require()`'d code is base-trusted; trust-input files (DENOUNCED/VOUCHED/CODEOWNERS/templates) are still fetched via the REST API against `base.ref` for defense in depth.
- Added `evaluate.test.js` (27 cases) and `close.test.js` (7 cases) using Node 20's built-in `node:test` runner — no `package.json`, no deps. Tests cover every branch of the decision tree, including the specific regression cases for the CODEOWNERS regex and `/assign` composition fixes.
- Added `.github/workflows/pr-gate-scripts.yml` to run `node --test` on changes to the gate workflow or its scripts. Read-only permissions, path filters so unrelated PRs don't trigger it.

## Net change

`pr-gate.yml`: 307 → 55 lines. Total workflow + scripts + tests + templates + lists: a small net increase, but the change is now structured code with unit coverage instead of a 300-line YAML heredoc.

## Commits (logical order, one per fix)

| commit | what |
|---|---|
| `e1021a2f` | declare explicit workflow permissions |
| `294928ee` | skip team handles in CODEOWNERS parsing |
| `5cb9ffb5` | compose `/assign` across codeowners and within comments |
| `c4abb3f0` | extract rejection messages into template files |
| `eb2d9b71` | allow outside collaborators with explicit repo access |
| `a16e2a0e` | add denounce list to auto-close known bad actors |
| `d8c04ba8` | add vouched allowlist for trusted external contributors |
| `f8d3ec8e` | consolidate eligibility ladder into a single script |
| `7332f7c7` | extract workflow scripts to `.github/scripts/pr-gate/` |
| `22d1d6e8` | add tests for `evaluate.js` and `close.js` |
| `c725d08a` | add CI to run the pr-gate script tests |

## Test plan

- [x] `node --test` from `.github/scripts/pr-gate/` — 34 tests pass
- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` on both workflow files — valid YAML
- [ ] Once merged, watch the first external PR exercise the gate and confirm the close comment renders cleanly (no more accidental code-block indentation)
- [ ] Verify `pr-gate-scripts.yml` runs on a follow-up PR touching any file under `.github/scripts/pr-gate/`

## Out of scope (worth a follow-up)

- Team-handle expansion in CODEOWNERS — currently skipped; could be resolved via `orgs.listMembersForTeam` if the project ever moves to team-based ownership.
- `/unassign @user` syntax — revocation today is "close the PR".

---

### PR author checklist

#### Contribution eligibility

- [x] I am a core contributor, OR I have been explicitly assigned to the linked issue
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and my PR complies with all requirements
- [x] I understand that PRs not meeting these requirements will be closed without review

#### For all contributors

- [ ] Reference a GitHub issue
- [x] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [ ] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
