### PR TITLE
chore: Port downstream fork commits upstream

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -51,6 +51,7 @@
 - Changed `Msg::StartHeight` from `StartHeight(Height, ValidatorSet)` to `StartHeight(Height, HeightParams)` ([#1227](https://github.com/circlefin/malachite/pull/1227))
 - Changed `Msg::RestartHeight` from `RestartHeight(Height, ValidatorSet)` to `RestartHeight(Height, HeightParams)` ([#1227](https://github.com/circlefin/malachite/pull/1227))
 - Added `timeouts` field to `State` struct - timeouts are now stored in State instead of Driver ([#1227](https://github.com/circlefin/malachite/pull/1227))
+- Added `WalEntry::PolkaCertificate` variant - polka certificates are now stored in the WAL; if recovering with downgraded version fails, restart with the new version 
 
 ### `malachitebft-config`
 

--- a/code/crates/core-consensus/src/handle/liveness.rs
+++ b/code/crates/core-consensus/src/handle/liveness.rs
@@ -2,6 +2,7 @@ use crate::handle::driver::apply_driver_input;
 use crate::prelude::*;
 
 use super::signature::{verify_polka_certificate, verify_round_certificate};
+use crate::types::WalEntry;
 
 /// Handles the processing of a polka certificate.
 ///
@@ -40,6 +41,21 @@ where
         return Ok(());
     }
 
+    // Skip certificate processing if one is already stored, to avoid redundant
+    // signature verification, duplicate WAL appends, and no-op driver inputs.
+    if state
+        .polka_certificate(certificate.round, &certificate.value_id)
+        .is_some()
+    {
+        debug!(
+            %certificate.height,
+            %certificate.round,
+            "Polka certificate already known, ignoring"
+        );
+
+        return Ok(());
+    }
+
     let validator_set = state.validator_set();
 
     let validity = verify_polka_certificate(
@@ -54,6 +70,15 @@ where
         warn!(?certificate, "Invalid polka certificate: {e}");
         return Ok(());
     }
+
+    perform!(
+        co,
+        Effect::WalAppend(
+            certificate.height,
+            WalEntry::PolkaCertificate(certificate.clone()),
+            Default::default()
+        )
+    );
 
     apply_driver_input(
         co,

--- a/code/crates/core-consensus/src/handle/vote.rs
+++ b/code/crates/core-consensus/src/handle/vote.rs
@@ -27,6 +27,7 @@ where
             consensus.round = %consensus_round,
             vote.height = %vote_height,
             vote.round = %vote_round,
+            vote.msg = %PrettyVote::<Ctx>(&signed_vote.message),
             validator = %validator_address,
             "Received vote for lower height, dropping"
         );
@@ -41,6 +42,7 @@ where
             consensus.round = %consensus_round,
             vote.height = %vote_height,
             vote.round = %vote_round,
+            vote.msg = %PrettyVote::<Ctx>(&signed_vote.message),
             validator = %validator_address,
             "Received vote for higher height, queuing for later"
         );
@@ -59,6 +61,7 @@ where
             consensus.round = %consensus_round,
             vote.height = %vote_height,
             vote.round = %vote_round,
+            vote.msg = %PrettyVote::<Ctx>(&signed_vote.message),
             validator = %validator_address,
             "Received vote at round -1, queuing for later"
         );

--- a/code/crates/core-consensus/src/types.rs
+++ b/code/crates/core-consensus/src/types.rs
@@ -102,6 +102,7 @@ pub enum WalEntry<Ctx: Context> {
     ConsensusMsg(SignedConsensusMsg<Ctx>),
     Timeout(Timeout),
     ProposedValue(ProposedValue<Ctx>),
+    PolkaCertificate(PolkaCertificate<Ctx>),
 }
 
 impl<Ctx: Context> WalEntry<Ctx> {

--- a/code/crates/core-consensus/tests/restart_validation.rs
+++ b/code/crates/core-consensus/tests/restart_validation.rs
@@ -1,0 +1,247 @@
+//! Deterministic test that crash recovery via WAL replay reproduces v3's
+//! pre-crash voting behaviour when v3's pre-crash `Prevote(value, r=1)` was
+//! justified by a `PolkaCertificate(r=0)` received over the liveness layer.
+//!
+//! The test drives v3 through the pre-crash scenario, capturing every
+//! `WalAppend` effect along the way. It then replays exactly those entries
+//! against a fresh state. Then it fires the r=1 propose timer that the engine
+//! would re-schedule once it resumes real time after replay.
+//!
+//! The post-replay assertion is that v3's published-vote set after replay
+//! exactly equals its pre-crash published-vote set. Subset in one direction
+//! catches equivocation; subset in the other catches a WAL that fails to
+//! capture enough state to deterministically reconstruct the pre-crash run.
+//! Together they assert recovery is both safe and complete.
+
+use std::vec::Vec;
+
+use arc_malachitebft_core_consensus::{
+    process, Effect, Error, Input, Params, ProposedValue, Resumable, Resume, SignedConsensusMsg,
+    State, ValuePayload, WalEntry,
+};
+use malachitebft_core_types::{
+    NilOrVal, PolkaCertificate, Round, RoundCertificate, RoundCertificateType, SignedProposal,
+    SignedVote, Timeout, Validity, ValueOrigin, VoteType,
+};
+use malachitebft_metrics::Metrics;
+use malachitebft_test::utils::validators::make_validators;
+use malachitebft_test::{
+    Address, Height, Proposal, Signature, TestContext, Validator, ValidatorSet, Value, ValueId,
+    Vote,
+};
+
+#[derive(Default)]
+struct Captured {
+    wal: Vec<WalEntry<TestContext>>,
+    published_votes: Vec<SignedVote<TestContext>>,
+}
+
+fn handle_effect(
+    effect: Effect<TestContext>,
+    cap: &mut Captured,
+) -> Result<Resume<TestContext>, ()> {
+    use Effect::*;
+    Ok(match effect {
+        VerifySignature(_, _, r) => r.resume_with(true),
+        VerifyPolkaCertificate(_, _, _, r) => r.resume_with(Ok(())),
+        VerifyRoundCertificate(_, _, _, r) => r.resume_with(Ok(())),
+        VerifyCommitCertificate(_, _, _, r) => r.resume_with(Ok(())),
+        SignVote(vote, r) => r.resume_with(SignedVote::new(vote, Signature::test())),
+        SignProposal(proposal, r) => {
+            r.resume_with(SignedProposal::new(proposal, Signature::test()))
+        }
+        WalAppend(_, entry, r) => {
+            cap.wal.push(entry);
+            r.resume_with(())
+        }
+        PublishConsensusMsg(msg, r) => {
+            if let SignedConsensusMsg::Vote(v) = &msg {
+                cap.published_votes.push(v.clone());
+            }
+            r.resume_with(())
+        }
+        ExtendVote(_, _, _, r) => r.resume_with(None),
+        VerifyVoteExtension(_, _, _, _, _, r) => r.resume_with(Ok(())),
+        _ => Resume::Continue,
+    })
+}
+
+fn drive(
+    state: &mut State<TestContext>,
+    inputs: Vec<Input<TestContext>>,
+    cap: &mut Captured,
+    metrics: &Metrics,
+) {
+    for input in inputs {
+        let _: Result<(), Error<TestContext>> = process!(
+            input: input,
+            state: state,
+            metrics: metrics,
+            with: e => handle_effect(e, cap)
+        );
+    }
+}
+
+fn make_state(validators: &[Validator], my_addr: Address) -> State<TestContext> {
+    let vs = ValidatorSet::new(validators.to_vec());
+    State::new(
+        TestContext::new(),
+        Height::new(1),
+        vs,
+        Params {
+            address: my_addr,
+            threshold_params: Default::default(),
+            value_payload: ValuePayload::ProposalAndParts,
+            enabled: true,
+        },
+        1000,
+        1000,
+    )
+}
+
+fn prevote(addr: Address, round: u32, value_id: NilOrVal<ValueId>) -> SignedVote<TestContext> {
+    SignedVote::new(
+        Vote::new_prevote(Height::new(1), Round::new(round), value_id, addr),
+        Signature::test(),
+    )
+}
+
+fn precommit(addr: Address, round: u32, value_id: NilOrVal<ValueId>) -> SignedVote<TestContext> {
+    SignedVote::new(
+        Vote::new_precommit(Height::new(1), Round::new(round), value_id, addr),
+        Signature::test(),
+    )
+}
+
+#[test]
+fn restart_with_polka_certificate() {
+    let validators: Vec<_> = make_validators([2, 3, 2])
+        .into_iter()
+        .map(|(v, _)| v)
+        .collect();
+    let v1 = validators[0].address;
+    let v2 = validators[1].address;
+    let v3 = validators[2].address;
+    let vs = ValidatorSet::new(validators.clone());
+    let value = Value::new(0x37a5);
+    let value_id = value.id();
+
+    // Ordered consensus inputs to v3 before the crash.
+    let inputs: Vec<Input<TestContext>> = vec![
+        // Enter h=1, r=0.
+        Input::StartHeight(Height::new(1), vs.clone(), false, None),
+        // Propose timer at r=0 fires: v3 prevotes nil at r=0.
+        Input::TimeoutElapsed(Timeout::propose(Round::new(0))),
+        // Peers' Precommit RoundCertificate(r=0, nil) carries 2f+1 precommits
+        // and schedules v3's precommit timer at r=0.
+        Input::RoundCertificate(RoundCertificate::new_from_votes(
+            Height::new(1),
+            Round::new(0),
+            RoundCertificateType::Precommit,
+            vec![
+                precommit(v1, 0, NilOrVal::Nil),
+                precommit(v2, 0, NilOrVal::Nil),
+            ],
+        )),
+        // Precommit timer at r=0 fires: v3 advances to r=1.
+        Input::TimeoutElapsed(Timeout::precommit(Round::new(0))),
+        // PolkaCertificate(r=0, value) attached to v2's r=1 re-proposal,
+        // received via the liveness layer.
+        Input::PolkaCertificate(PolkaCertificate::new(
+            Height::new(1),
+            Round::new(0),
+            value_id,
+            vec![
+                prevote(v1, 0, NilOrVal::Val(value_id)),
+                prevote(v2, 0, NilOrVal::Val(value_id)),
+            ],
+        )),
+        // Re-proposal from v2 (the r=1 proposer) with pol_round=0.
+        Input::Proposal(SignedProposal::new(
+            Proposal::new(
+                Height::new(1),
+                Round::new(1),
+                value.clone(),
+                Round::new(0),
+                v2,
+            ),
+            Signature::test(),
+        )),
+        // Application supplies the full value (ProposalAndParts mode); this
+        // matches the stored proposal and drives v3 to `Prevote(value, r=1)`
+        // via L28.
+        Input::ProposedValue(
+            ProposedValue {
+                height: Height::new(1),
+                round: Round::new(1),
+                valid_round: Round::new(0),
+                proposer: v2,
+                value: value.clone(),
+                validity: Validity::Valid,
+            },
+            ValueOrigin::Consensus,
+        ),
+    ];
+
+    // Consensus phase: v3 lives through the pre-crash scenario.
+    let metrics = Metrics::new();
+    let mut state_normal = make_state(&validators, v3);
+    let mut cap_normal = Captured::default();
+    drive(&mut state_normal, inputs, &mut cap_normal, &metrics);
+
+    // Sanity: v3 emitted the pre-crash Prevote(value, r=1).
+    assert!(
+        cap_normal.published_votes.iter().any(|v| {
+            v.message.height == Height::new(1)
+                && v.message.round == Round::new(1)
+                && v.message.typ == VoteType::Prevote
+                && matches!(v.message.value, NilOrVal::Val(id) if id == value_id)
+        }),
+        "v3 should have emitted Prevote(value, r=1) before crash; got {:?}",
+        cap_normal.published_votes,
+    );
+
+    // Recovery phase: replay the captured WAL entries to a fresh state.
+    let mut replay_inputs: Vec<Input<TestContext>> =
+        vec![Input::StartHeight(Height::new(1), vs, true, None)];
+    for entry in cap_normal.wal.drain(..) {
+        replay_inputs.push(match entry {
+            WalEntry::ConsensusMsg(SignedConsensusMsg::Vote(v)) => Input::Vote(v),
+            WalEntry::ConsensusMsg(SignedConsensusMsg::Proposal(p)) => Input::Proposal(p),
+            WalEntry::ProposedValue(pv) => Input::ProposedValue(pv, ValueOrigin::Consensus),
+            WalEntry::Timeout(t) => Input::TimeoutElapsed(t),
+            WalEntry::PolkaCertificate(c) => Input::PolkaCertificate(c),
+        });
+    }
+    // The propose timer for r=1 was scheduled when v3 entered r=1 during replay.
+    replay_inputs.push(Input::TimeoutElapsed(Timeout::propose(Round::new(1))));
+
+    let metrics = Metrics::new();
+    let mut state_replay = make_state(&validators, v3);
+    let mut cap_replay = Captured::default();
+    drive(&mut state_replay, replay_inputs, &mut cap_replay, &metrics);
+
+    // The published-vote sets must be equal: WAL replay deterministically
+    // re-derives every pre-crash vote (timeouts are WAL'd, so on replay they
+    // re-fire via `Input::TimeoutElapsed` and the state machine reproduces the
+    // same outputs).
+    assert_eq!(cap_replay.published_votes, cap_normal.published_votes);
+
+    // Guards restored from the WAL.
+    assert_eq!(
+        state_replay.driver.last_prevote(),
+        state_normal.driver.last_prevote(),
+    );
+    assert_eq!(
+        state_replay.driver.last_precommit(),
+        state_normal.driver.last_precommit(),
+    );
+    assert_eq!(
+        state_replay.driver.round_state().locked,
+        state_normal.driver.round_state().locked,
+    );
+    assert_eq!(
+        state_replay.driver.round_state().valid,
+        state_normal.driver.round_state().valid,
+    );
+}

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -1013,6 +1013,25 @@ where
                         return Err(e);
                     }
                 }
+
+                WalEntry::PolkaCertificate(certificate) => {
+                    info!("Replaying polka certificate: {certificate:?}");
+
+                    if let Err(e) = self
+                        .process_input(myself, state, ConsensusInput::PolkaCertificate(certificate))
+                        .await
+                    {
+                        error!("Error when replaying PolkaCertificate: {e}");
+
+                        let e = Arc::new(e);
+                        self.tx_event.send({
+                            let e = Arc::clone(&e);
+                            || Event::WalReplayError(e)
+                        });
+
+                        return Err(e);
+                    }
+                }
             }
         }
 

--- a/code/crates/engine/src/consensus.rs
+++ b/code/crates/engine/src/consensus.rs
@@ -21,8 +21,8 @@ use malachitebft_core_consensus::{
     Effect, LivenessMsg, PeerId, Resumable, Resume, SignedConsensusMsg, VoteExtensionError,
 };
 use malachitebft_core_types::{
-    CommitCertificate, Context, Proposal, Round, Timeout, TimeoutKind, Timeouts, ValidatorProof,
-    ValidatorSet, Value, ValueId, ValueOrigin, ValueResponse as CoreValueResponse, Vote,
+    Context, Proposal, Round, Timeout, TimeoutKind, Timeouts, ValidatorProof, ValidatorSet, Value,
+    ValueId, ValueOrigin, ValueResponse as CoreValueResponse, Vote,
 };
 use malachitebft_metrics::Metrics;
 use malachitebft_signing::{Signer, Verifier, VerifierExt};
@@ -133,8 +133,9 @@ pub enum Msg<Ctx: Context> {
     /// This triggers notifying the sync actor about the decided height.
     DecisionCommitted(Ctx::Height),
 
-    /// The WAL replay delay has elapsed; replay WAL entries or skip if sync succeeded.
-    WalReplayDelayElapsed,
+    /// The WAL replay delay has elapsed for the given height; if we are still in
+    /// `WaitingForSync` at the same height, replay the WAL.
+    WalReplayDelayElapsed(Ctx::Height),
 
     /// Request to dump the current consensus state
     DumpState(RpcReplyPort<Option<StateDump<Ctx>>>),
@@ -186,7 +187,9 @@ impl<Ctx: Context> fmt::Display for Msg<Ctx> {
                 write!(f, "RestartHeight(height={height} params={params:?})")
             }
             Msg::DecisionCommitted(height) => write!(f, "DecisionCommitted(height={height})"),
-            Msg::WalReplayDelayElapsed => write!(f, "WalReplayDelayElapsed"),
+            Msg::WalReplayDelayElapsed(height) => {
+                write!(f, "WalReplayDelayElapsed(height={height})")
+            }
             Msg::DumpState(_) => write!(f, "DumpState"),
         }
     }
@@ -504,9 +507,10 @@ where
 
                     // Schedule the WAL replay delay timer
                     let actor = myself.clone();
+                    let timer_height = height;
                     state.wal_replay_timer = Some(tokio::spawn(async move {
                         tokio::time::sleep(wal_replay_delay).await;
-                        let _ = actor.cast(Msg::WalReplayDelayElapsed);
+                        let _ = actor.cast(Msg::WalReplayDelayElapsed(timer_height));
                     }));
 
                     return Ok(());
@@ -776,16 +780,54 @@ where
                 // The application has confirmed that the decision has been committed.
                 // Notify the sync actor so it can advertise this height to peers.
                 self.sync.send(SyncMsg::Decided(height));
+
+                debug_assert_eq!(
+                    height,
+                    state.height(),
+                    "DecisionCommitted height must match current state height"
+                );
+
+                // If we were waiting for a sync certificate to apply, the cert has
+                // now driven the state machine to a decision. Transition out of
+                // `WaitingForSync`: cancel the timer, discard the unused pending
+                // WAL entries, and process any buffered messages.
+                if state.phase == Phase::WaitingForSync && height == state.height() {
+                    info!(
+                        %height,
+                        "Sync certificate applied; transitioning out of WaitingForSync"
+                    );
+
+                    if let Some(handle) = state.wal_replay_timer.take() {
+                        handle.abort();
+                    }
+                    state.pending_wal_entries.clear();
+
+                    state.set_phase(Phase::Running);
+                    self.process_buffered_msgs(&myself, state, false).await;
+                }
+
                 Ok(())
             }
 
-            Msg::WalReplayDelayElapsed => {
-                if state.phase != Phase::WaitingForSync {
-                    // Already moved past WaitingForSync (e.g., due to a new StartHeight).
+            Msg::WalReplayDelayElapsed(timer_height) => {
+                if state.phase != Phase::WaitingForSync || state.height() != timer_height {
+                    // Stale timer fire: we have moved past `WaitingForSync` of the height
+                    // the timer was set up for.
                     return Ok(());
                 }
 
-                self.end_wal_wait(&myself, state, false).await;
+                // The driver has already decided this height; the in-flight
+                // `Msg::DecisionCommitted` will handle the transition out of
+                // `WaitingForSync`. Resetting here would wipe the decision.
+                if state
+                    .consensus
+                    .as_ref()
+                    .is_some_and(|c| c.driver.step_is_commit())
+                {
+                    return Ok(());
+                }
+
+                self.end_wal_wait(&myself, state).await;
 
                 Ok(())
             }
@@ -1146,19 +1188,17 @@ where
         Ok(())
     }
 
-    /// End the `WaitingForSync` phase.
+    /// End the `WaitingForSync` phase by replaying the WAL.
     ///
-    /// If `skip_wal_replay` is true, the WAL is reset (entries discarded) because
-    /// a verified sync certificate makes replay unnecessary. Otherwise, the pending
-    /// WAL entries are replayed to restore the pre-crash consensus state.
+    /// Called when the WAL-replay delay timer elapses without consensus having
+    /// reached a decision via the sync-certificate path. Resets the consensus
+    /// state (discarding any partial sync-certificate data), replays the
+    /// pending WAL entries to restore the pre-crash consensus state,
+    /// transitions to `Running`, then drains the message buffer.
     ///
-    /// In both cases the phase transitions to `Running` and buffered messages are processed.
-    async fn end_wal_wait(
-        &self,
-        myself: &ActorRef<Msg<Ctx>>,
-        state: &mut State<Ctx>,
-        skip_wal_replay: bool,
-    ) {
+    /// The pre-replay consensus reset preserves the assumption that WAL replay
+    /// only reconstructs state, it does not lead to e.g. a new decision.
+    async fn end_wal_wait(&self, myself: &ActorRef<Msg<Ctx>>, state: &mut State<Ctx>) {
         if let Some(handle) = state.wal_replay_timer.take() {
             handle.abort();
         }
@@ -1166,24 +1206,40 @@ where
         let height = state.height();
         let wal_entries = std::mem::take(&mut state.pending_wal_entries);
 
-        if skip_wal_replay {
-            info!(
-                %height,
-                "Verified sync certificate during delay, skipping WAL replay"
-            );
-
-            hang_on_failure(self.wal_reset(height), |e| {
-                error!(%height, "Error when resetting WAL after sync success: {e}");
-            })
-            .await;
-        } else if !wal_entries.is_empty() {
+        if !wal_entries.is_empty() {
             info!(
                 %height,
                 entries = wal_entries.len(),
-                "WAL replay delay elapsed without valid sync certificate, replaying WAL"
+                "WAL replay delay elapsed without consensus reaching a decision, replaying WAL"
             );
 
+            // Transition to `Recovering` *before* the driver reset so that any effects
+            // emitted during the StartHeight result in no-op `wal_flush` calls.
             state.set_phase(Phase::Recovering);
+
+            let validator_set = state
+                .consensus
+                .as_ref()
+                .expect("consensus must be initialized when leaving WaitingForSync")
+                .validator_set()
+                .clone();
+
+            hang_on_failure(
+                self.process_input(
+                    myself,
+                    state,
+                    ConsensusInput::StartHeight(
+                        height,
+                        validator_set,
+                        false, // not a `Msg::RestartHeight`; we're just resetting consensus state
+                        None,  // a target time here would be moot
+                    ),
+                ),
+                |e| {
+                    error!(%height, "Error re-initializing core state before WAL replay: {e}");
+                },
+            )
+            .await;
 
             hang_on_failure(self.wal_replay(myself, state, height, wal_entries), |e| {
                 error!(%height, "Error when replaying WAL: {e}");
@@ -1194,37 +1250,6 @@ where
 
         state.set_phase(Phase::Running);
         self.process_buffered_msgs(myself, state, false).await;
-    }
-
-    /// Verify a commit certificate from a sync response at the engine layer.
-    ///
-    /// Returns `true` if the certificate is cryptographically valid,
-    /// `false` if verification fails or the consensus state is unavailable.
-    async fn verify_sync_certificate(
-        &self,
-        state: &State<Ctx>,
-        certificate: &CommitCertificate<Ctx>,
-    ) -> bool {
-        let Some(consensus) = state.consensus.as_ref() else {
-            return false;
-        };
-
-        // Defensive: reject certificates for a different height
-        if certificate.height != consensus.height() {
-            return false;
-        }
-
-        let validator_set = consensus.validator_set();
-
-        self.verifier
-            .verify_commit_certificate(
-                &self.ctx,
-                certificate,
-                validator_set,
-                self.params.threshold_params,
-            )
-            .await
-            .is_ok()
     }
 
     async fn handle_effect(
@@ -1732,26 +1757,10 @@ where
         msg: Msg<Ctx>,
         state: &mut State<Ctx>,
     ) -> Result<(), ActorProcessingErr> {
-        if state.phase != Phase::Running && should_buffer(&msg) {
-            // If sync delivers a certificate while we wait, verify it.
-            // If valid, skip WAL replay entirely. If invalid, let the timer expire normally.
-            if state.phase == Phase::WaitingForSync && matches!(&msg, Msg::ProcessSyncResponse(_)) {
-                let is_valid_certificate = if let Msg::ProcessSyncResponse(ref response) = msg {
-                    self.verify_sync_certificate(state, &response.certificate)
-                        .await
-                } else {
-                    false
-                };
+        // During `WaitingForSync`, sync-related messages must flow through.
+        let bypass_buffer = state.phase == Phase::WaitingForSync && is_sync_application_msg(&msg);
 
-                if is_valid_certificate {
-                    state.msg_buffer.buffer(msg);
-                    self.end_wal_wait(&myself, state, true).await;
-                    return Ok(());
-                }
-
-                // Certificate invalid — fall through to the generic buffer path below
-            }
-
+        if !bypass_buffer && state.phase != Phase::Running && should_buffer(&msg) {
             let _span = error_span!("buffer", phase = ?state.phase).entered();
             state.msg_buffer.buffer(msg);
             return Ok(());
@@ -1792,10 +1801,18 @@ fn should_buffer<Ctx: Context>(msg: &Msg<Ctx>) -> bool {
         msg,
         Msg::StartHeight(..)
             | Msg::DecisionCommitted(..)
-            | Msg::WalReplayDelayElapsed
+            | Msg::WalReplayDelayElapsed(..)
             | Msg::NetworkEvent(NetworkEvent::Listening(..))
             | Msg::NetworkEvent(NetworkEvent::PeerConnected(..))
             | Msg::NetworkEvent(NetworkEvent::PeerDisconnected(..))
+    )
+}
+
+/// Whether `msg` is part of the sync-certificate application chain.
+fn is_sync_application_msg<Ctx: Context>(msg: &Msg<Ctx>) -> bool {
+    matches!(
+        msg,
+        Msg::ProcessSyncResponse(..) | Msg::ReceivedProposedValue(_, ValueOrigin::Sync)
     )
 }
 

--- a/code/crates/engine/src/wal.rs
+++ b/code/crates/engine/src/wal.rs
@@ -17,6 +17,7 @@ mod thread;
 
 pub use entry::WalCodec;
 pub use entry::WalEntry;
+pub use entry::{decode_entry, encode_entry};
 pub use iter::log_entries;
 
 pub type WalRef<Ctx> = ActorRef<Msg<Ctx>>;

--- a/code/crates/engine/src/wal/entry.rs
+++ b/code/crates/engine/src/wal/entry.rs
@@ -4,17 +4,20 @@ use byteorder::{ReadBytesExt, WriteBytesExt, BE};
 
 use malachitebft_codec::Codec;
 use malachitebft_core_consensus::{ProposedValue, SignedConsensusMsg};
-use malachitebft_core_types::{Context, Round, Timeout};
+use malachitebft_core_types::{Context, PolkaCertificate, Round, Timeout};
 
 /// Codec for encoding and decoding WAL entries.
 ///
 /// This trait is automatically implemented for any type that implements:
 /// - [`Codec<SignedConsensusMsg<Ctx>>`]
+/// - [`Codec<ProposedValue<Ctx>>`]
+/// - [`Codec<PolkaCertificate<Ctx>>`]
 pub trait WalCodec<Ctx>
 where
     Ctx: Context,
     Self: Codec<SignedConsensusMsg<Ctx>>,
     Self: Codec<ProposedValue<Ctx>>,
+    Self: Codec<PolkaCertificate<Ctx>>,
 {
 }
 
@@ -23,6 +26,7 @@ where
     Ctx: Context,
     C: Codec<SignedConsensusMsg<Ctx>>,
     C: Codec<ProposedValue<Ctx>>,
+    C: Codec<PolkaCertificate<Ctx>>,
 {
 }
 
@@ -31,6 +35,7 @@ pub use malachitebft_core_consensus::WalEntry;
 const TAG_CONSENSUS: u8 = 0x01;
 const TAG_TIMEOUT: u8 = 0x02;
 const TAG_PROPOSED_VALUE: u8 = 0x04;
+const TAG_POLKA_CERTIFICATE: u8 = 0x08;
 
 pub fn encode_entry<Ctx, C, W>(entry: &WalEntry<Ctx>, codec: &C, buf: W) -> io::Result<()>
 where
@@ -43,6 +48,9 @@ where
         WalEntry::Timeout(timeout) => encode_timeout(TAG_TIMEOUT, timeout, buf),
         WalEntry::ProposedValue(value) => {
             encode_proposed_value(TAG_PROPOSED_VALUE, value, codec, buf)
+        }
+        WalEntry::PolkaCertificate(certificate) => {
+            encode_polka_certificate(TAG_POLKA_CERTIFICATE, certificate, codec, buf)
         }
     }
 }
@@ -59,6 +67,9 @@ where
         TAG_CONSENSUS => decode_consensus_msg(codec, buf).map(WalEntry::ConsensusMsg),
         TAG_TIMEOUT => decode_timeout(buf).map(WalEntry::Timeout),
         TAG_PROPOSED_VALUE => decode_proposed_value(codec, buf).map(WalEntry::ProposedValue),
+        TAG_POLKA_CERTIFICATE => {
+            decode_polka_certificate(codec, buf).map(WalEntry::PolkaCertificate)
+        }
         _ => Err(io::Error::new(io::ErrorKind::InvalidData, "invalid tag")),
     }
 }
@@ -235,6 +246,48 @@ where
         io::Error::new(
             io::ErrorKind::InvalidData,
             format!("failed to decode proposed value: {e}"),
+        )
+    })
+}
+
+fn encode_polka_certificate<Ctx, C, W>(
+    tag: u8,
+    certificate: &PolkaCertificate<Ctx>,
+    codec: &C,
+    mut buf: W,
+) -> io::Result<()>
+where
+    Ctx: Context,
+    C: WalCodec<Ctx>,
+    W: Write,
+{
+    let bytes = codec.encode(certificate).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to encode polka certificate: {e}"),
+        )
+    })?;
+
+    buf.write_u8(tag)?;
+    buf.write_u64::<BE>(bytes.len() as u64)?;
+    buf.write_all(&bytes)?;
+    Ok(())
+}
+
+fn decode_polka_certificate<Ctx, C, R>(codec: &C, mut buf: R) -> io::Result<PolkaCertificate<Ctx>>
+where
+    Ctx: Context,
+    C: WalCodec<Ctx>,
+    R: Read,
+{
+    let len = buf.read_u64::<BE>()?;
+    let mut bytes = vec![0; len as usize];
+    buf.read_exact(&mut bytes)?;
+
+    codec.decode(bytes.into()).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to decode polka certificate: {e}"),
         )
     })
 }

--- a/code/crates/engine/src/wal/thread.rs
+++ b/code/crates/engine/src/wal/thread.rs
@@ -284,5 +284,6 @@ fn wal_entry_type<Ctx: Context>(entry: &WalEntry<Ctx>) -> &'static str {
         },
         WalEntry::ProposedValue(_) => "LocallyProposedValue",
         WalEntry::Timeout(_) => "Timeout",
+        WalEntry::PolkaCertificate(_) => "PolkaCertificate",
     }
 }

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -937,16 +937,22 @@ where
 ///
 /// If the candidate violates either invariant, it is raised to the next
 /// uncovered height at or above `tip_height + 1`.
+///
+/// Only the pending-range skip is logged: callers are expected to pass a
+/// candidate outside every pending range, so a skip there means an unsafe
+/// value was passed in. The tip-floor bump (candidate ≤ tip_height) is the
+/// routine post-decide/rollback path and is not logged.
 fn set_sync_height<Ctx: Context>(state: &mut State<Ctx>, candidate: Ctx::Height) {
     let floor = max(state.tip_height.increment(), candidate);
     let new_sync_height = find_next_uncovered_height::<Ctx>(floor, &state.pending_requests);
 
-    if new_sync_height != candidate {
+    if new_sync_height != floor {
         warn!(
             %candidate,
             tip_height = %state.tip_height,
+            floor = %floor,
             sync_height = %new_sync_height,
-            "Adjusted sync_height from candidate to satisfy invariants"
+            "sync_height candidate is inside a pending request range; advancing past it"
         );
     }
 

--- a/code/crates/test/src/codec/proto/mod.rs
+++ b/code/crates/test/src/codec/proto/mod.rs
@@ -315,6 +315,20 @@ impl Codec<ProposedValue<TestContext>> for ProtobufCodec {
     }
 }
 
+impl Codec<PolkaCertificate<TestContext>> for ProtobufCodec {
+    type Error = ProtoError;
+
+    fn decode(&self, bytes: Bytes) -> Result<PolkaCertificate<TestContext>, Self::Error> {
+        let proto = proto::PolkaCertificate::decode(bytes.as_ref())?;
+        decode_polka_certificate(proto)
+    }
+
+    fn encode(&self, msg: &PolkaCertificate<TestContext>) -> Result<Bytes, Self::Error> {
+        let proto = encode_polka_certificate(msg)?;
+        Ok(Bytes::from(proto.encode_to_vec()))
+    }
+}
+
 impl Codec<sync::Status<TestContext>> for ProtobufCodec {
     type Error = ProtoError;
 
@@ -472,8 +486,6 @@ pub fn decode_synced_value(
     })
 }
 
-// NOTE: Will be used again in #997
-#[allow(dead_code)]
 pub(crate) fn encode_polka_certificate(
     polka_certificate: &PolkaCertificate<TestContext>,
 ) -> Result<proto::PolkaCertificate, ProtoError> {
@@ -499,8 +511,6 @@ pub(crate) fn encode_polka_certificate(
     })
 }
 
-// NOTE: Will be used again in #997
-#[allow(dead_code)]
 pub(crate) fn decode_polka_certificate(
     certificate: proto::PolkaCertificate,
 ) -> Result<PolkaCertificate<TestContext>, ProtoError> {
@@ -675,9 +685,49 @@ impl Codec<ValidatorProof<TestContext>> for ProtobufCodec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Address, Height};
-    use malachitebft_core_types::{NilOrVal, Round, RoundSignature, VoteType};
+    use crate::{Address, Height, ValueId};
+    use malachitebft_core_types::{NilOrVal, PolkaSignature, Round, RoundSignature, VoteType};
     use malachitebft_signing_ed25519::Signature;
+
+    #[test]
+    fn test_polka_certificate_encode_decode() {
+        let height = Height::new(7);
+        let round = Round::new(3);
+        let value_id = ValueId::new(0xC0FFEE);
+        let address_a = Address::new([1; 20]);
+        let address_b = Address::new([2; 20]);
+        let signature_a = Signature::from_bytes([3; 64]);
+        let signature_b = Signature::from_bytes([4; 64]);
+
+        let certificate = PolkaCertificate {
+            height,
+            round,
+            value_id,
+            polka_signatures: vec![
+                PolkaSignature::new(address_a, signature_a),
+                PolkaSignature::new(address_b, signature_b),
+            ],
+        };
+
+        let encoded = encode_polka_certificate(&certificate).unwrap();
+        let decoded = decode_polka_certificate(encoded).unwrap();
+
+        assert_eq!(decoded.height, certificate.height);
+        assert_eq!(decoded.round, certificate.round);
+        assert_eq!(decoded.value_id, certificate.value_id);
+        assert_eq!(
+            decoded.polka_signatures.len(),
+            certificate.polka_signatures.len()
+        );
+        for (got, want) in decoded
+            .polka_signatures
+            .iter()
+            .zip(certificate.polka_signatures.iter())
+        {
+            assert_eq!(got.address, want.address);
+            assert_eq!(got.signature.to_bytes(), want.signature.to_bytes());
+        }
+    }
 
     #[test]
     fn test_round_certificate_encode_decode() {

--- a/code/crates/test/tests/it/wal.rs
+++ b/code/crates/test/tests/it/wal.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use eyre::bail;
@@ -7,9 +9,10 @@ use arc_malachitebft_test::{self as malachitebft_test};
 
 use malachitebft_config::ValuePayload;
 use malachitebft_core_consensus::LocallyProposedValue;
-use malachitebft_core_types::SignedVote;
+use malachitebft_core_types::{Round, SignedVote};
 use malachitebft_engine::util::events::Event;
-use malachitebft_test::TestContext;
+use malachitebft_test::middleware::Middleware;
+use malachitebft_test::{Height, TestContext};
 
 use crate::middlewares::{ByzantineProposer, PrevoteNil};
 use crate::{HandlerResult, TestBuilder, TestParams};
@@ -444,4 +447,144 @@ async fn multi_rounds_1() {
 #[tokio::test]
 async fn multi_rounds_2() {
     test_multi_rounds(3, Duration::from_secs(10)).await
+}
+
+#[tokio::test]
+async fn sync_recovery_handles_multiple_certificates() {
+    #[derive(Clone, Debug, Default)]
+    struct State {
+        decisions_at_crash_height: u32,
+    }
+
+    const CRASH_HEIGHT: u64 = 3;
+    const FINAL_HEIGHT: u64 = CRASH_HEIGHT + 2;
+
+    let mut test = TestBuilder::<State>::new();
+
+    test.add_node()
+        .start()
+        .wait_until(CRASH_HEIGHT)
+        // Wait for an `Event::Published` so the WAL is not empty when crashing.
+        .on_event(|event, _| match event {
+            Event::Published(_) => Ok(HandlerResult::ContinueTest),
+            _ => Ok(HandlerResult::WaitForNextEvent),
+        })
+        .crash()
+        // While the validator is down, the other three keep making progress.
+        .restart_after(Duration::from_secs(10))
+        // Catch up via sync (no WAL replay), and assert idempotence: only one
+        // `Decided` at `CRASH_HEIGHT`.
+        .on_event(move |event, state| match event {
+            Event::WalReplayBegin(height, count) => {
+                bail!(
+                    "Unexpected WAL replay at height {height} with {count} entries; \
+                     expected sync to deliver a certificate during WaitingForSync"
+                );
+            }
+            Event::Decided { commit_certificate } => {
+                let h = commit_certificate.height.as_u64();
+                if h < CRASH_HEIGHT {
+                    bail!(
+                        "Decided at height {h} < CRASH_HEIGHT={CRASH_HEIGHT}: \
+                         unexpected height regression after recovery"
+                    );
+                }
+                if h == CRASH_HEIGHT {
+                    state.decisions_at_crash_height += 1;
+                    if state.decisions_at_crash_height > 1 {
+                        bail!(
+                            "Duplicate Decided at CRASH_HEIGHT={CRASH_HEIGHT}: \
+                             bypass is not idempotent under multi-peer cert delivery"
+                        );
+                    }
+                    Ok(HandlerResult::WaitForNextEvent)
+                } else {
+                    Ok(HandlerResult::ContinueTest)
+                }
+            }
+            _ => Ok(HandlerResult::WaitForNextEvent),
+        })
+        .wait_until(FINAL_HEIGHT)
+        .success();
+
+    test.add_node().start().wait_until(FINAL_HEIGHT).success();
+    test.add_node().start().wait_until(FINAL_HEIGHT).success();
+    test.add_node().start().wait_until(FINAL_HEIGHT).success();
+
+    test.build()
+        .run_with_params(
+            Duration::from_secs(90),
+            TestParams {
+                enable_value_sync: true,
+                ..TestParams::default()
+            },
+        )
+        .await
+}
+
+/// Middleware that fails `ProcessSyncedValue` decode while a shared flag is set.
+#[derive(Debug, Clone)]
+struct FailSyncDecodeWhileFlagSet {
+    fail: Arc<AtomicBool>,
+}
+
+impl Middleware for FailSyncDecodeWhileFlagSet {
+    fn fail_synced_value_decode(&self, _ctx: &TestContext, _height: Height, _round: Round) -> bool {
+        self.fail.load(Ordering::SeqCst)
+    }
+}
+
+/// Regression test for the WAL-replay-delay sync path. Without the fix,
+/// `WalReplayBegin` would never fire, because the original `end_wal_wait` would call `wal_reset`.
+#[tokio::test]
+async fn sync_recovery_falls_back_to_wal_replay_on_decode_failure() {
+    const CRASH_HEIGHT: u64 = 3;
+    const FINAL_HEIGHT: u64 = CRASH_HEIGHT + 2;
+
+    let fail = Arc::new(AtomicBool::new(true));
+    let middleware = FailSyncDecodeWhileFlagSet {
+        fail: Arc::clone(&fail),
+    };
+
+    let mut test = TestBuilder::<()>::new();
+
+    test.add_node()
+        .with_middleware(middleware)
+        .start()
+        .wait_until(CRASH_HEIGHT)
+        // Wait for an `Event::Published` so the WAL is not empty when crashing.
+        .on_event(|event, _| match event {
+            Event::Published(_) => Ok(HandlerResult::ContinueTest),
+            _ => Ok(HandlerResult::WaitForNextEvent),
+        })
+        .crash()
+        // While the validator is down, the other three keep making progress.
+        .restart_after(Duration::from_secs(10))
+        .on_event(move |event, _| match event {
+            Event::WalReplayBegin(height, _count) if height.as_u64() == CRASH_HEIGHT => {
+                info!("Observed WAL replay at crash height; clearing fail-decode flag");
+                fail.store(false, Ordering::SeqCst);
+                Ok(HandlerResult::ContinueTest)
+            }
+            Event::WalReplayBegin(height, _count) => {
+                bail!("Unexpected WAL replay at height {height}, expected {CRASH_HEIGHT}");
+            }
+            _ => Ok(HandlerResult::WaitForNextEvent),
+        })
+        .wait_until(FINAL_HEIGHT)
+        .success();
+
+    test.add_node().start().wait_until(FINAL_HEIGHT).success();
+    test.add_node().start().wait_until(FINAL_HEIGHT).success();
+    test.add_node().start().wait_until(FINAL_HEIGHT).success();
+
+    test.build()
+        .run_with_params(
+            Duration::from_secs(90),
+            TestParams {
+                enable_value_sync: true,
+                ..TestParams::default()
+            },
+        )
+        .await
 }

--- a/code/crates/test/tests/unit/main.rs
+++ b/code/crates/test/tests/unit/main.rs
@@ -1,3 +1,4 @@
 mod certificates;
 mod sync;
 mod validator_proof;
+mod wal_codec;

--- a/code/crates/test/tests/unit/wal_codec.rs
+++ b/code/crates/test/tests/unit/wal_codec.rs
@@ -1,0 +1,153 @@
+//! Round-trip tests for the WAL frame codec (`engine::wal::{encode_entry, decode_entry}`).
+//!
+//! These tests cover the tag-byte + u64-length-prefix + codec-bytes framing
+//! that `engine/src/wal/entry.rs` wraps around each `WalEntry` variant before
+//! it is appended to the on-disk WAL. The framing is shared by all variants,
+//! so a regression in any one variant's tag dispatch, length prefix, or codec
+//! call is caught here without needing a multi-node end-to-end test.
+
+use std::io::Cursor;
+
+use arc_malachitebft_test::codec::proto::ProtobufCodec;
+use arc_malachitebft_test::{
+    Address, Height, Proposal, Signature, TestContext, Value, ValueId, Vote,
+};
+
+use malachitebft_core_consensus::{ProposedValue, SignedConsensusMsg, WalEntry};
+use malachitebft_core_types::{
+    NilOrVal, PolkaCertificate, PolkaSignature, Round, SignedProposal, SignedVote, Timeout,
+    Validity,
+};
+use malachitebft_engine::wal::{decode_entry, encode_entry};
+
+fn round_trip(entry: &WalEntry<TestContext>) -> WalEntry<TestContext> {
+    let codec = ProtobufCodec;
+    let mut buf = Vec::new();
+    encode_entry(entry, &codec, &mut buf).expect("encode_entry");
+    decode_entry(&codec, Cursor::new(buf)).expect("decode_entry")
+}
+
+#[test]
+fn wal_entry_consensus_msg_vote_round_trip() {
+    let vote = SignedVote::new(
+        Vote::new_prevote(
+            Height::new(11),
+            Round::new(2),
+            NilOrVal::Val(ValueId::new(0xDEAD)),
+            Address::new([9; 20]),
+        ),
+        Signature::test(),
+    );
+
+    let entry = WalEntry::ConsensusMsg(SignedConsensusMsg::Vote(vote.clone()));
+    let decoded = round_trip(&entry);
+
+    let WalEntry::ConsensusMsg(SignedConsensusMsg::Vote(got)) = decoded else {
+        panic!("expected ConsensusMsg::Vote variant, got {decoded:?}");
+    };
+    assert_eq!(got.message, vote.message);
+    assert_eq!(got.signature.to_bytes(), vote.signature.to_bytes());
+}
+
+#[test]
+fn wal_entry_consensus_msg_proposal_round_trip() {
+    let proposal = SignedProposal::new(
+        Proposal::new(
+            Height::new(11),
+            Round::new(2),
+            Value::new(0xBEEF),
+            Round::new(1),
+            Address::new([9; 20]),
+        ),
+        Signature::test(),
+    );
+
+    let entry = WalEntry::ConsensusMsg(SignedConsensusMsg::Proposal(proposal.clone()));
+    let decoded = round_trip(&entry);
+
+    let WalEntry::ConsensusMsg(SignedConsensusMsg::Proposal(got)) = decoded else {
+        panic!("expected ConsensusMsg::Proposal variant, got {decoded:?}");
+    };
+    assert_eq!(got.message, proposal.message);
+    assert_eq!(got.signature.to_bytes(), proposal.signature.to_bytes());
+}
+
+#[test]
+fn wal_entry_timeout_round_trip() {
+    for timeout in [
+        Timeout::propose(Round::new(0)),
+        Timeout::prevote(Round::new(1)),
+        Timeout::precommit(Round::new(2)),
+        Timeout::rebroadcast(Round::new(3)),
+    ] {
+        let entry = WalEntry::Timeout(timeout);
+        let decoded = round_trip(&entry);
+        let WalEntry::Timeout(got) = decoded else {
+            panic!("expected Timeout variant, got {decoded:?}");
+        };
+        assert_eq!(got.kind, timeout.kind);
+        assert_eq!(got.round, timeout.round);
+    }
+}
+
+#[test]
+fn wal_entry_proposed_value_round_trip() {
+    let pv = ProposedValue::<TestContext> {
+        height: Height::new(42),
+        round: Round::new(0),
+        valid_round: Round::Nil,
+        proposer: Address::new([7; 20]),
+        value: Value::new(0xABCD),
+        validity: Validity::Valid,
+    };
+
+    let entry = WalEntry::ProposedValue(pv.clone());
+    let decoded = round_trip(&entry);
+
+    let WalEntry::ProposedValue(got) = decoded else {
+        panic!("expected ProposedValue variant, got {decoded:?}");
+    };
+    assert_eq!(got, pv);
+}
+
+#[test]
+fn wal_entry_polka_certificate_round_trip() {
+    let cert = PolkaCertificate {
+        height: Height::new(7),
+        round: Round::new(3),
+        value_id: ValueId::new(0xC0FFEE),
+        polka_signatures: vec![
+            PolkaSignature::new(Address::new([1; 20]), Signature::test()),
+            PolkaSignature::new(Address::new([2; 20]), Signature::test()),
+        ],
+    };
+
+    let entry = WalEntry::PolkaCertificate(cert.clone());
+    let decoded = round_trip(&entry);
+
+    let WalEntry::PolkaCertificate(got) = decoded else {
+        panic!("expected PolkaCertificate variant, got {decoded:?}");
+    };
+    assert_eq!(got.height, cert.height);
+    assert_eq!(got.round, cert.round);
+    assert_eq!(got.value_id, cert.value_id);
+    assert_eq!(got.polka_signatures.len(), cert.polka_signatures.len());
+    for (got_sig, want_sig) in got
+        .polka_signatures
+        .iter()
+        .zip(cert.polka_signatures.iter())
+    {
+        assert_eq!(got_sig.address, want_sig.address);
+        assert_eq!(got_sig.signature.to_bytes(), want_sig.signature.to_bytes());
+    }
+}
+
+/// A buffer with an invalid leading tag byte must surface as a decode error
+/// rather than panicking or returning a bogus entry.
+#[test]
+fn wal_entry_invalid_tag_is_rejected() {
+    let codec = ProtobufCodec;
+    let buf = vec![0xFFu8]; // 0xFF is not assigned to any variant
+    let result = decode_entry::<TestContext, _, _>(&codec, Cursor::new(buf));
+    assert!(result.is_err(), "decode_entry should reject unknown tags");
+}


### PR DESCRIPTION
## Summary

Brings 3 commits forward from a downstream fork of Malachite.

## Test plan

- [x] `cargo check --workspace --tests --all-features` passes locally
- [x] `cargo fmt --all --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)