### PR TITLE
chore(ci): bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       specs: ${{ steps.filter.outputs.specs }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
         id: filter
         with:
@@ -48,7 +48,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
         with:
@@ -72,7 +72,7 @@ jobs:
       - name: Generate text report
         run: cargo llvm-cov report
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-coverage
           path: code/coverage-integration.info
@@ -97,13 +97,13 @@ jobs:
   #     CARGO_TERM_COLOR: always
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+  #       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
   #     - name: Install Protoc
   #       uses: step-security/setup-protoc@f6eb248a6510dbb851209febc1bd7981604a52e3 # v3
   #       with:
   #         repo-token: ${{ secrets.GITHUB_TOKEN }}
   #     - name: Setup Node
-  #       uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+  #       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
   #       with:
   #         node-version: "18"
   #     - name: Install Quint
@@ -126,7 +126,7 @@ jobs:
   #     - name: Generate text report
   #       run: cargo llvm-cov report
   #     - name: Upload coverage artifact
-  #       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+  #       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
   #       with:
   #         name: mbt-coverage
   #         path: code/coverage-mbt.info
@@ -147,16 +147,16 @@ jobs:
     if: ${{ !cancelled() && (needs.changes.outputs.code == 'true' || needs.changes.outputs.specs == 'true' || needs.changes.outputs.codecov == 'true' || github.ref == 'refs/heads/main') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Create coverage directory
         run: mkdir -p code/coverage
       - name: Download integration coverage
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: integration-coverage
           path: code/coverage
       # - name: Download MBT coverage
-      #   uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      #   uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       #   with:
       #     name: mbt-coverage
       #     path: code/coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
         id: filter
         with:
@@ -39,14 +39,14 @@ jobs:
         working-directory: code
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           cache-workspaces: "code"
       - name: Setup pages
         id: pages
-        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Clean docs folder
         run: cargo clean --doc
       - name: Build docs
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,7 +10,7 @@ jobs:
   linkChecker:
     runs-on: github-hosted-small
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/mbt.yml
+++ b/.github/workflows/mbt.yml
@@ -15,7 +15,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       specs: ${{ steps.filter.outputs.specs }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
         id: filter
         with:
@@ -39,9 +39,9 @@ jobs:
       RUSTUP_MAX_RETRIES: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Node
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "18"
       - name: Install Quint

--- a/.github/workflows/need-triage-label.yml
+++ b/.github/workflows/need-triage-label.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: github-hosted-small
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check if opener is CODEOWNER
         id: check-codeowner
@@ -30,7 +30,7 @@ jobs:
 
       - name: Add need-triage label
         if: steps.check-codeowner.outputs.is_codeowner == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             try {

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check if author is allowed bot
         id: check-dependabot
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
@@ -22,7 +22,7 @@ jobs:
       - name: Check if author is codeowner
         id: check-codeowner
         if: steps.check-dependabot.outputs.is_allowed_bot == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
@@ -59,7 +59,7 @@ jobs:
         if: |
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
@@ -86,7 +86,7 @@ jobs:
           steps.check-dependabot.outputs.is_allowed_bot == 'false' &&
           steps.check-codeowner.outputs.is_codeowner == 'false' &&
           steps.check-org-member.outputs.is_org_member == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
@@ -141,7 +141,7 @@ jobs:
           steps.check-org-member.outputs.is_org_member == 'false' &&
           steps.check-assignment.outputs.is_assigned == 'false' &&
           steps.check-assignment.outputs.reason == 'not_assigned_to_issue'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
@@ -217,7 +217,7 @@ jobs:
           steps.check-org-member.outputs.is_org_member == 'false' &&
           steps.check-assignment.outputs.is_assigned == 'false' &&
           steps.check-tagged-by-codeowner.outputs.is_tagged_by_codeowner != 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const reason = '${{ steps.check-assignment.outputs.reason }}';

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check signatures and cleanup comments
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             // 1. Fetch all commits in the PR (handling pagination)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:

--- a/.github/workflows/quint.yml
+++ b/.github/workflows/quint.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       specs: ${{ steps.filter.outputs.specs }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
         id: filter
         with:
@@ -30,8 +30,8 @@ jobs:
     if: ${{ needs.changes.outputs.specs == 'true' || github.ref == 'refs/heads/main' }}
     runs-on: github-hosted-small
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "18"
       - run: npm install -g @informalsystems/quint
@@ -45,8 +45,8 @@ jobs:
     env:
       MAX_SAMPLES: 100
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "18"
       - run: npm install -g @informalsystems/quint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
         id: filter
         with:
@@ -40,9 +40,9 @@ jobs:
         working-directory: code
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # - name: Setup Node
-      #   uses: actions/setup-node@v3
+      #   uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       #   with:
       #     node-version: "18"
       # - name: Install Quint
@@ -72,9 +72,9 @@ jobs:
         working-directory: code
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # - name: Setup Node
-      #   uses: actions/setup-node@v3
+      #   uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       #   with:
       #     node-version: "18"
       # - name: Install Quint
@@ -111,7 +111,7 @@ jobs:
         working-directory: code
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
@@ -125,7 +125,7 @@ jobs:
     runs-on: github-hosted-small
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
@@ -142,7 +142,7 @@ jobs:
     runs-on: github-hosted-small
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
@@ -162,7 +162,7 @@ jobs:
       run:
         working-directory: code
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           toolchain: stable
@@ -183,7 +183,7 @@ jobs:
       run:
         working-directory: code
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           toolchain: stable

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: step-security/paths-filter@6eee183b0d2fd101d3f8ee2935c127bca14c5625 # v3.0.5
         id: filter
         with:
@@ -40,7 +40,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
           toolchain: stable
@@ -55,7 +55,7 @@ jobs:
         id: extract_branch
       - name: Restore Rustdoc cache
         id: restore-cache-rustdoc
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: code/target/semver-checks/cache
           key: ${{ runner.os }}-semver-${{ steps.extract_branch.outputs.branch }}-${{ hashFiles('**/Cargo.lock') }}
@@ -101,13 +101,13 @@ jobs:
         continue-on-error: true
       - name: Save Rustdoc cache
         id: save-cache-rustdoc
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: code/target/semver-checks/cache
           key: ${{ runner.os }}-semver-${{ steps.extract_branch.outputs.branch }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Post comment on PR if violation found
         if: steps.semver-check.outputs.has_violations == 'true'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -180,7 +180,7 @@ jobs:
             }
       - name: Update PR comment when violations are fixed
         if: steps.semver-check.outputs.has_violations == 'false'
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/todo-tracking.yml
+++ b/.github/workflows/todo-tracking.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
 
@@ -30,7 +30,7 @@ jobs:
         run: python scripts/todos.py
 
       - name: Update issue and timestamp
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,5 +15,5 @@ jobs:
     name: Check spelling
     runs-on: github-hosted-small
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: crate-ci/typos@30eea72e385d435c00a24eeba0d96f87048f42ec # master


### PR DESCRIPTION
Closes: #1565

## Summary

Bulk SHA-pin update of GitHub Actions to their latest Node-24-compatible release. Pre-emptive migration ahead of GitHub Actions runner Node 20 removal in Fall 2026.

## Actions bumped

- `actions/checkout@v4.3.1`/`v4` → `df4cb1c0…` (v6.0.3)
- `actions/upload-artifact@v4` → `043fb46d…` (v7.0.1)
- `actions/setup-node@v3.9.1`/`v3` → `48b55a01…` (v6.4.0)
- `actions/download-artifact@v4.3.0` → `3e5f45b2…` (v8.0.1)
- `actions/configure-pages@v4.0.0` → `45bfe019…` (v6.0.0)
- `actions/deploy-pages@v4.0.5` → `cd2ce8fc…` (v5.0.0)
- `actions/github-script@v7.1.0`/`v6.4.1` → `3a2844b7…` (v9.0.0)
- `actions/cache/restore@v4.3.0`, `actions/cache/save@v4.3.0` → `27d5ce7f…` (v5.0.5)
- `actions/setup-python@v4.9.1` → `a309ff8b…` (v6.2.0)

## Verification

Every emitted SHA was verified via `gh api /repos/<owner>/<repo>/commits/<sha>` before commit.

## Background

Node 20 is being removed from GitHub Actions runners in Fall 2026 (see [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This PR pre-emptively bumps every pinned third-party action to its first Node-24-compatible release so the workflows keep running on the new runner default.