### PR TITLE
fix(sync): preserve rewound `sync_height` after concurrent re-request

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -64,6 +64,7 @@
   peer-score update by the `received / requested` ratio
 - Reject sync responses with non-contiguous certificate heights ([#1541](https://github.com/circlefin/malachite/issues/1541))
 - Fix partial range request not being tracked in pending requests
+- Preserve a sync_height rewind when a concurrent re-request to a different range succeeds, so the rewound range is picked up by the next request cycle instead of being silently abandoned
 - Initial random (fixed) period adjustment in sync status ticker
 - Refactor sync actor to notify consensus of sync responses
 - Support batch retrieval of decided values

--- a/code/crates/sync/src/handle.rs
+++ b/code/crates/sync/src/handle.rs
@@ -805,8 +805,13 @@ where
         },
     );
 
-    // Update sync_height to the next uncovered height after this range
-    set_sync_height(state, final_range.end().increment());
+    // Advance sync_height past this range only if it sat inside the range.
+    // If sync_height is already below the range — because a concurrent
+    // exhaustion path rewound it to an earlier untracked range — leave it
+    // alone so the next request cycle picks that range up.
+    if final_range.contains(&state.sync_height) {
+        set_sync_height(state, final_range.end().increment());
+    }
 
     Ok(())
 }
@@ -1813,6 +1818,111 @@ mod tests {
         // sync_height should have been reset but remain above tip_height.
         // sync_height should reset to the start of the failed range (11),
         // which is above tip_height (10).
+        assert_eq!(state.sync_height, Height::new(11));
+    }
+
+    #[test]
+    fn test_re_request_preserves_rewound_sync_height_below_other_pending_range() {
+        let mut state = make_test_state();
+        state.started = true;
+        let metrics = crate::Metrics::new(std::time::Duration::from_secs(10));
+
+        state.tip_height = Height::new(10);
+        state.sync_height = Height::new(21);
+
+        let peer_a = PeerId::random();
+        let peer_b = PeerId::random();
+
+        state.peers.insert(
+            peer_a,
+            crate::Status {
+                peer_id: peer_a,
+                tip_height: Height::new(30),
+                history_min_height: Height::new(1),
+            },
+        );
+        state.peers.insert(
+            peer_b,
+            crate::Status {
+                peer_id: peer_b,
+                tip_height: Height::new(30),
+                history_min_height: Height::new(1),
+            },
+        );
+
+        // Entry A holds heights 11..=15 and has already excluded peer_a, so
+        // when peer_b also times out, every eligible peer is exhausted and
+        // sync_height rewinds to 11.
+        state.pending_requests.insert(
+            OutboundRequestId::new("req_a"),
+            PendingRequestEntry {
+                range: Height::new(11)..=Height::new(15),
+                peer: peer_b,
+                excluded_peers: [peer_a].into_iter().collect(),
+            },
+        );
+
+        // Entry B holds heights 16..=20 with peer_a still available as a
+        // retry target.
+        state.pending_requests.insert(
+            OutboundRequestId::new("req_b"),
+            PendingRequestEntry {
+                range: Height::new(16)..=Height::new(20),
+                peer: peer_b,
+                excluded_peers: BTreeSet::new(),
+            },
+        );
+
+        // Entry A times out on peer_b — all eligible peers exhausted.
+        drive_input_with_retries(
+            &mut state,
+            &metrics,
+            Input::SyncRequestTimedOut(
+                OutboundRequestId::new("req_a"),
+                peer_b,
+                crate::Request::ValueRequest(crate::ValueRequest::new(
+                    Height::new(11)..=Height::new(15),
+                )),
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            state.sync_height,
+            Height::new(11),
+            "exhaustion should rewind sync_height to the start of the failed range"
+        );
+
+        // Entry B times out on peer_b — peer_a is still eligible, so a new
+        // request goes out. sync_height must stay at 11 so the next request
+        // cycle picks up the 11..=15 range that the exhaustion rewound to.
+        let effects = drive_input_with_retries(
+            &mut state,
+            &metrics,
+            Input::SyncRequestTimedOut(
+                OutboundRequestId::new("req_b"),
+                peer_b,
+                crate::Request::ValueRequest(crate::ValueRequest::new(
+                    Height::new(16)..=Height::new(20),
+                )),
+            ),
+        )
+        .unwrap();
+
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::SendValueRequest(..))),
+            "Expected a re-request to be sent for entry B"
+        );
+
+        let req_b_entry = state
+            .pending_requests
+            .values()
+            .find(|entry| entry.range == (Height::new(16)..=Height::new(20)))
+            .expect("re-requested entry for 16..=20 should be present");
+        assert_eq!(req_b_entry.peer, peer_a);
+
         assert_eq!(state.sync_height, Height::new(11));
     }
 


### PR DESCRIPTION
## Problem

After the peer-exhaustion handler in
`re_request_values_from_peer_except` rewinds `sync_height` to the start of a failed range, a concurrent re-request for a *different* in-flight range completes and runs `set_sync_height(state,
final_range.end().increment())` at the end of
`send_and_track_request_to_peer`. That unconditional forward set clobbers the rewind, leaving the rewound range out of `pending_requests` and below `sync_height`, so it is never picked up by future `request_values` cycles.

## Solution

Make the forward set in `send_and_track_request_to_peer` conditional on `sync_height` actually sitting inside the range that was just inserted. If `sync_height` is already below the range — because another path rewound it — leave it alone.

## Tests

Added
`test_re_request_preserves_rewound_sync_height_below_other_pending_range` in `code/crates/sync/src/handle.rs`. The test:

- Seeds two pending entries. The first has its alternate peer already excluded, the second has a healthy peer available.
- Times out the first entry, so the exhaustion path rewinds `sync_height` to its range start.
- Times out the second entry, so the re-request goes to the remaining peer and succeeds.
- Asserts `sync_height` stays at the rewound value rather than being pushed past the second range's end.

Confirmed the test fails on the unfixed code with the exact symptom (`sync_height == 21` instead of `11`) and passes with the fix.

---

### PR author checklist

#### Contribution eligibility

- [x] I am a core contributor, OR I have been explicitly assigned to the linked issue
- [x] I have read [CONTRIBUTING.md](/CONTRIBUTING.md) and my PR complies with all requirements
- [x] I understand that PRs not meeting these requirements will be closed without review

#### For all contributors

- [x] Reference a GitHub issue
- [x] Ensure the PR title follows the [conventional commits][conv-commits] spec
- [x] Add a release note in [`RELEASE_NOTES.md`](/RELEASE_NOTES.md) if the change warrants it
- [ ] Add an entry in [`BREAKING_CHANGES.md`](/BREAKING_CHANGES.md) if the change warrants it

[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
