### PR TITLE
docs(core-consensus): fix stale comment on round certificate validation

### DIFF
--- a/code/crates/core-consensus/src/handle/liveness.rs
+++ b/code/crates/core-consensus/src/handle/liveness.rs
@@ -105,9 +105,10 @@ where
 /// the vote keeper will still be able to generate the threshold output using the existing
 /// stored and incoming votes from the certificate.
 ///
-/// (*) There is currently no validation of the correctness of the certificate in this function.
-/// A byzantine validator may send a certificate that does not have enough votes to reach the
-/// thresholds for `PrecommitAny` or `SkipRound`.
+/// The round certificate is fully validated by `verify_round_certificate`,
+/// which checks each vote signature and enforces the required voting-power
+/// threshold for `PrecommitAny` (2f+1) or `SkipRound` (f+1) before this
+/// function applies the certificate to the driver.
 ///
 /// # Returns
 /// * `Result<(), Error<Ctx>>` - Ok(()) if processing completed successfully,


### PR DESCRIPTION
Closes: #1569

## Summary

The comment above `on_round_certificate` in `handle/liveness.rs` states:

> There is currently no validation of the correctness of the certificate in this function. A byzantine validator may send a certificate that does not have enough votes to reach the thresholds for PrecommitAny or SkipRound.

This is no longer accurate. Commit 961fa4e0 ("fix: Reject certificates with any invalid signature") added full validation via `verify_round_certificate` in `signing/src/ext.rs`:

- Rejects duplicate votes from the same validator
- Rejects votes from unknown validators
- Rejects mismatched vote types for Precommit certificates
- Verifies each individual signature
- Enforces the 2f+1 (quorum) threshold for PrecommitAny and f+1 (honest) threshold for SkipRound

The comment was never updated after that fix landed, which could mislead future contributors into thinking this validation gap still exists.

## Change

Updated the doc comment to accurately describe the current validation behavior.

No functional changes.