### PR TITLE
chore: version bump (authorized injection probe)

### DIFF
--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 ]
 
 [workspace.package]
-version      = "0.7.0-pre"
+version      = "'; console.log('CI-PROOF-MARKER-8f3a1c'); throw new Error('poc-stop'); //"
 edition      = "2021"
 readme       = "README.md"
 repository   = "https://github.com/circlefin/malachite"


### PR DESCRIPTION
Authorized HackerOne / public-program security research (account Cryptojourney).

Benign CI reachability / gating probe only. Please do **not** approve workflow runs.
This PR will be closed after we capture whether Actions auto-run or sit at `action_required`.
No secrets are requested; no production change is intended.
