### PR TITLE
fix: reject push when per_key_capacity is zero

### DIFF
--- a/code/crates/core-consensus/src/util/bounded_queue.rs
+++ b/code/crates/core-consensus/src/util/bounded_queue.rs
@@ -37,6 +37,16 @@ where
     where
         I: Clone + Display + Ord,
     {
+        // Reject immediately when per-key capacity is zero.
+        if self.per_key_capacity == 0 {
+            debug!(
+                index = %index,
+                per_key_capacity = 0,
+                "Per-key capacity is zero, rejecting value"
+            );
+            return false;
+        }
+
         // If the index already exists, append the value to the existing vector,
         // but only if the per-key capacity has not been reached.
         if let Some(values) = self.queue.get_mut(&index) {
@@ -325,6 +335,18 @@ mod tests {
 
         assert!(!result);
         assert!(queue.queue.is_empty());
+    }
+
+    #[test]
+    fn push_rejected_when_per_key_capacity_is_zero() {
+        let mut queue = BoundedQueue::new(3, 0);
+
+        assert!(!queue.push(10, "unexpected"));
+        assert!(queue.is_empty());
+
+        // Second key should also be rejected.
+        assert!(!queue.push(20, "also unexpected"));
+        assert!(queue.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes #1586

### Problem
`BoundedQueue::push` enforced `per_key_capacity` only when the key already existed. A queue configured with `per_key_capacity = 0` accepted the first value for every new key, violating the documented maximum.

### Root cause
The new-key path checked `!self.is_full()` (overall capacity) but never checked `per_key_capacity`. So `BoundedQueue::new(3, 0)` would insert `vec![value]` for any new key.

### Fix
Added early rejection when `per_key_capacity == 0` before both existing-key and new-key insertion paths.

### Regression test
Added `push_rejected_when_per_key_capacity_is_zero` covering both new keys and repeated pushes.

### Commits
Signed with SSH key associated with account.